### PR TITLE
chore: prepare for release

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -40,7 +40,7 @@ Make targets mirror these (`make help`). Use `make build-vsix` / `make install-v
 
 ## Validation & CI
 
-- CI runs `npm run test:unit` on Node 20/22 and E2E on VSCode 1.100.0.
+- CI runs `npm run test:unit` on Node 20/22 and E2E on VSCode (min version from package.json)/stable.
 - Integration/E2E need VSCode runtime; they will fail headless—expected.
 - Pre-commit hooks (optional): gitleaks, prettier, markdownlint, shfmt, typos, codespell, shellcheck, JSON/YAML/TOML checks (`make enable-pre-commit-only` to install).
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -255,7 +255,7 @@ make enable-pre-commit-only
 
 ### Commit Message Guidelines
 
-**Use Conventional Commit format for all commits:**
+**Use [Conventional Commits](https://www.conventionalcommits.org/) format:**
 
 ```text
 <type>[optional scope]: <description>
@@ -264,6 +264,13 @@ make enable-pre-commit-only
 
 [optional footer(s)]
 ```
+
+**Rules:**
+
+- **Imperative mood**: "add feature" not "added feature" or "adds feature"
+- **Lowercase after colon**: first word is lowercase unless a proper noun (e.g., `feat: add ESLint rule`)
+- **Summary line**: ≤ 50 characters
+- **Body lines**: ≤ 72 characters (wrap longer explanations)
 
 **Common types:**
 
@@ -279,10 +286,9 @@ make enable-pre-commit-only
 
 **Examples:**
 
-- `feat: add toggle command for hiding all squiggles`
-- `fix: resolve status bar icon not updating correctly`
-- `docs: update README with new installation instructions`
-- `build: add comprehensive Copilot coding agent instructions`
+- `refactor!: consolidate redundant configurations`
+- `fix: restore colors after multiple toggles`
+- `docs(README.md): describe keyboard shortcuts`
 
 **For coding agents:** Always use conventional commit format when making changes to maintain consistency with the project's commit history.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,7 +6,7 @@
 
 - VSCode extension toggles error/warning/info/hint squiggles transparent.
 - Command: `invisible-squiggles.toggle`, status bar eye (👁️), global settings only.
-- Runtime: Node 20.x/22.x; VSCode ^1.100.0; ESBuild bundles to `dist/`.
+- Runtime: Node 20.x/22.x; VSCode (min version from package.json)/stable; ESBuild bundles to `dist/`.
 - Main code: `src/extension.ts`. Tests: `src/test/{unit,integration,e2e,helpers}/`.
 
 ## Core Commands (preferred order)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,360 +1,66 @@
 # Copilot Instructions for invisible-squiggles
 
-> **Note**: For a concise agent-focused guide, see `AGENTS.md` at the repository root. This file provides more detailed context and troubleshooting information.
+> Keep this concise for Copilot; richer context lives in `AGENTS.md`.
 
-## Repository Overview
+## Fast Facts
 
-**invisible-squiggles** is a VSCode extension that allows users to toggle error, warning, info, and hint squiggles for a distraction-free coding experience. The extension provides both a status bar button (👁️) and command palette integration to control squiggle visibility.
+- VSCode extension toggles error/warning/info/hint squiggles transparent.
+- Command: `invisible-squiggles.toggle`, status bar eye (👁️), global settings only.
+- Runtime: Node 20.x/22.x; VSCode ^1.100.0; ESBuild bundles to `dist/`.
+- Main code: `src/extension.ts`. Tests: `src/test/{unit,integration,e2e,helpers}/`.
 
-### Project Details
-
-- **Type**: VSCode Extension
-- **Language**: TypeScript
-- **Size**: Small focused project
-- **Runtime**: Node.js 20.x or 22.x, VSCode ^1.100.0
-- **Build System**: npm + ESBuild + TypeScript
-- **Package Manager**: npm
-- **Dependencies**: 16 dev dependencies
-- **Build Time**: ~2.5 seconds for full compile/package
-
-## Build & Development Instructions
-
-### Prerequisites
-
-- Node.js 20.x or 22.x
-- npm (comes with Node.js)
-- VSCode (for testing extension)
-
-### Essential Commands (Always run in this order)
-
-#### 1. Initial Setup
+## Core Commands (preferred order)
 
 ```bash
-npm install
+npm install          # setup
+npm run compile      # typecheck + lint + bundle (dev)
+npm run package      # production bundle
+npm run check-types  # type check only
+npm run lint         # eslint only
+npm test             # all tests (unit+integration+e2e)
+npm run test:unit    # fast, mocked VSCode, CI-safe
+npm run test:integration # needs VSCode
+npm run test:e2e         # needs Extension Dev Host
+npm run test:coverage    # coverage (warning thresholds)
+npm run watch        # TS + ESBuild watchers
 ```
 
-**Always run this first after cloning or when package.json changes.**
+Make targets mirror these (`make help`). Use `make build-vsix` / `make install-vsix` for packaging; it temporarily renames `README.md` to avoid vsce auto-include, cleans `dist/*.map`, then restores it.
 
-#### 2. Development Build
+## Development Flow
 
-```bash
-npm run compile
-```
+- Edit `src/extension.ts`; prefer single-file changes.
+- Run `npm run watch` while coding; reload VSCode window (`Cmd/Ctrl+R`) in the Extension Dev Host (F5) to test “Toggle Squiggles”.
+- Before commit: `npm run compile`; manual sanity check via F5 is recommended.
 
-**This runs type checking, linting, and builds the extension. Use for development.**
+## Behavior / Architecture
 
-#### 3. Production Build
+- Reads `workbench.colorCustomizations`, saves originals in `invisibleSquiggles.originalColors` (JSON string), applies `#00000000` to editor {Error|Warning|Info|Hint} {background|border|foreground}, restores on toggle.
+- All writes use `ConfigurationTarget.Global`.
 
-```bash
-npm run package
-```
+## Validation & CI
 
-**Creates optimized build for distribution. Use before publishing.**
+- CI runs `npm run test:unit` on Node 20/22 and E2E on VSCode 1.100.0.
+- Integration/E2E need VSCode runtime; they will fail headless—expected.
+- Pre-commit hooks (optional): gitleaks, prettier, markdownlint, shfmt, typos, codespell, shellcheck, JSON/YAML/TOML checks (`make enable-pre-commit-only` to install).
 
-#### 4. Type Checking
+## Common Fixes
 
-```bash
-npm run check-types
-```
+- Missing deps → `npm install` (or `make install`).
+- Type or lint failures → `npm run compile` / `npm run lint`.
+- Stale artifacts → `make rebuild` or `make clean && npm run package`.
+- VSIX includes extras → check `.vscodeignore`; README rename handled by `make build-vsix`.
+- Command/status bar missing → confirm activation events and command registration in `package.json` + `src/extension.ts`.
 
-**TypeScript type validation. Always passes currently.**
+## Commit & Release
 
-#### 5. Linting
+- Conventional Commits, imperative, ≤50 chars: `feat: add toggle`, `fix: restore colors`, etc.
+- Release sketch: update `CHANGELOG.md` + `package.json`, `make rebuild && make check`, `make install-vsix`, then tag/publish (`npx vsce publish`).
 
-```bash
-npm run lint
-```
+## Documentation Hygiene
 
-**ESLint validation. Always passes currently.**
+- Keep `README.md`, `AGENTS.md`, `CLAUDE.md`, and this file consistent. Update README immediately if behavior/commands change.
 
-#### 6. Testing
+## When to look elsewhere
 
-```bash
-npm test                 # Run all tests (unit + integration + E2E)
-npm run test:unit        # Run unit tests only (fast, < 5 seconds, no VSCode required)
-npm run test:integration # Run integration tests (requires VSCode runtime)
-npm run test:e2e         # Run E2E tests (requires Extension Development Host)
-npm run test:coverage    # Run all tests with coverage report
-```
-
-**Test Infrastructure**:
-
-- **Unit tests**: `src/test/unit/` - Fast tests with mocked VSCode APIs, execute in < 5 seconds
-- **Integration tests**: `src/test/integration/` - Tests with real VSCode APIs
-- **E2E tests**: `src/test/e2e/` - Full Extension Development Host tests
-- **Test helpers**: `src/test/helpers/` - Mock VSCode APIs and test utilities
-- **Coverage**: Configured with c8, shows line/branch/function/statement coverage with per-metric thresholds (warning only)
-
-**Note**: Integration and E2E tests require VSCode runtime and will fail in headless/CI environments. Unit tests can run without VSCode.
-
-### Watch Mode Development
-
-```bash
-npm run watch
-```
-
-**Starts both TypeScript and ESBuild watchers for continuous compilation during development.**
-
-### Makefile Targets
-
-The Makefile provides convenient automation. Run `make help` to see all targets:
-
-```bash
-make install      # Install dependencies (npm install)
-make build        # Production build (npm run package)
-make rebuild      # Clean and rebuild
-make check        # Run type checking, lint, and tests
-make build-vsix   # Build VSIX package for distribution
-make install-vsix # Build and install VSIX locally for testing
-make uninstall    # Uninstall extension from VSCode
-make clean        # Remove build artifacts (dist/, out/, *.vsix)
-```
-
-### VSCode Extension Development
-
-1. Press `F5` in VSCode to launch Extension Development Host
-2. Run "Toggle Squiggles" command in the new window to test
-3. Check status bar for eye icon (👁️)
-4. Use `Ctrl+R` (Windows/Linux) or `Cmd+R` (Mac) to reload after changes
-
-## Project Architecture
-
-### Key Files & Directories
-
-#### Source Code
-
-- `src/extension.ts` - Main extension implementation
-- `src/test/` - Comprehensive test suite
-  - `unit/` - Unit tests with mocked VSCode APIs
-  - `integration/` - Integration tests with real VSCode APIs
-  - `e2e/` - End-to-end tests in Extension Development Host
-  - `helpers/` - Test utilities and mock helpers
-
-#### Configuration Files
-
-- `package.json` - Extension manifest, scripts, and dependencies
-- `tsconfig.json` - TypeScript compiler configuration
-- `eslint.config.mjs` - ESLint rules and configuration
-- `esbuild.js` - Build bundling configuration
-
-#### VSCode Integration
-
-- `.vscode/launch.json` - Debug configuration for extension development
-- `.vscode/tasks.json` - Build and watch tasks
-- `.vscode/extensions.json` - Recommended extensions for development
-- `.vscodeignore` - Files excluded from extension package
-
-#### Build Output
-
-- `dist/` - ESBuild output (production bundle)
-- `out/` - TypeScript compiler output (tests)
-
-#### VSIX Packaging
-
-The VSIX package is built using `make build-vsix` (or `make install-vsix` to build and install locally).
-
-**What happens during `make build-vsix`:**
-
-1. Renames `README.md` to `README.md.hidden` (prevents vsce from auto-including it)
-2. Removes any stale sourcemaps (`dist/*.map`)
-3. Runs `npx vsce package` to create the `.vsix` file
-4. Restores `README.md` via `trap` (even on failure)
-
-**Why exclude README.md and CHANGELOG.md from VSIX?**
-
-- The VSIX is what users download/install — it should be minimal
-- The VS Code Marketplace reads these files directly during `npx vsce publish`, not from the VSIX
-- Both files remain fully visible on the Marketplace listing
-- This reduces VSIX download size without affecting the user experience
-
-**Note**: The `.vscodeignore` uses an allowlist pattern (`**` excludes all, then `!` negates specific files to include). The README.md rename is needed because vsce auto-includes README.md regardless of `.vscodeignore`.
-
-### Extension Architecture
-
-The extension uses VSCode's `workbench.colorCustomizations` setting to make squiggles transparent by setting editor colors to `#00000000`. It maintains original colors in a JSON string within the settings for restoration.
-
-**Key Components:**
-
-- Command registration: `invisible-squiggles.toggle`
-- Status bar item with eye icon
-- Configuration settings for each squiggle type (Error, Warning, Info, Hint)
-- Color customization persistence
-
-## Validation Pipeline
-
-### Pre-commit Hooks
-
-The repository uses extensive pre-commit hooks (see `.pre-commit-config.yaml`):
-
-- **Security**: gitleaks for secret detection
-- **Formatting**: prettier, markdownlint, shfmt
-- **Linting**: typos, codespell, shellcheck
-- **Validation**: JSON/YAML/TOML syntax checking
-
-**Note**: Pre-commit requires separate installation. To enable if pre-commit is available:
-
-```bash
-make enable-pre-commit-only
-```
-
-**Alternative Git Hooks**: Custom commit hooks are available in `.githooks/` (commit-msg, prepare-commit-msg).
-
-### GitHub Workflows
-
-- `ci.yml` - CI pipeline: unit tests (Node 20.x/22.x) and E2E tests (VSCode 1.100.0/stable)
-- `greet-new-contributors.yml` - Welcomes new contributors
-
-### Manual Validation Steps
-
-1. **Build validation**: `npm run compile` must pass
-2. **Type checking**: `npm run check-types` must pass
-3. **Linting**: `npm run lint` must pass
-4. **Extension testing**: Use F5 to test in Extension Development Host
-
-## Common Issues & Solutions
-
-### Build Issues
-
-- **Missing dependencies**: Run `npm install` or `make install`
-- **Type errors**: Check `tsconfig.json` and run `npm run check-types`
-- **ESLint errors**: Run `npm run lint` and fix reported issues
-- **Build failures**: Clean and rebuild with `make rebuild` (or `make clean && make build`)
-- **Dependency warnings**: npm shows deprecated package warnings - these are expected and don't affect functionality
-- **VSIX contains unexpected files**: Check `.vscodeignore` allowlist pattern
-
-### Extension Development
-
-- **Extension not loading**: Check `package.json` activation events and main entry point
-- **Commands not working**: Verify command registration in both `package.json` and `extension.ts`
-- **Watch mode not updating**: Restart watch task or reload VSCode window with `Ctrl/Cmd+R`
-- **Status bar not showing**: Extension activates on startup (`onStartupFinished`)
-
-### Testing Issues
-
-- **Tests fail in CI**: Expected behavior for integration/E2E tests - they require VSCode runtime. Unit tests can run in CI.
-- **Unit tests fail**: Check that `src/test/unit/setup.ts` is properly mocking VSCode APIs
-- **Integration/E2E tests fail**: Ensure VSCode test framework is properly configured in `.vscode-test.mjs`
-- **Coverage shows 0%**: Ensure `src/extension.ts` is included in coverage configuration
-- **Extension Test Runner not finding tests**: Ensure watch task is running via "Tasks: Run Task" menu
-
-## Development Workflow
-
-### Making Changes
-
-1. Start watch mode: `npm run watch`
-2. Make changes to `src/extension.ts`
-3. Press `F5` to launch Extension Development Host
-4. Test changes in the new VSCode window
-5. Use `Ctrl/Cmd+R` to reload after code changes
-
-### Before Committing
-
-1. Run `npm run compile` to ensure everything builds
-2. Test extension functionality manually
-3. Pre-commit hooks will run automatically if enabled
-
-### Commit Message Guidelines
-
-**Use [Conventional Commits](https://www.conventionalcommits.org/) format:**
-
-```text
-<type>[optional scope]: <description>
-
-[optional body]
-
-[optional footer(s)]
-```
-
-**Rules:**
-
-- **Imperative mood**: "add feature" not "added feature" or "adds feature"
-- **Lowercase after colon**: first word is lowercase unless a proper noun (e.g., `feat: add ESLint rule`)
-- **Summary line**: ≤ 50 characters
-- **Body lines**: ≤ 72 characters (wrap longer explanations)
-
-**Common types:**
-
-- `feat:` - New features
-- `fix:` - Bug fixes
-- `docs:` - Documentation changes
-- `style:` - Code style changes (formatting, missing semi-colons, etc.)
-- `refactor:` - Code refactoring
-- `test:` - Adding or updating tests
-- `chore:` - Maintenance tasks, dependency updates
-- `build:` - Build system changes
-- `ci:` - CI/CD configuration changes
-
-**Examples:**
-
-- `refactor!: consolidate redundant configurations`
-- `fix: restore colors after multiple toggles`
-- `docs(README.md): describe keyboard shortcuts`
-
-**For coding agents:** Always use conventional commit format when making changes to maintain consistency with the project's commit history.
-
-### Release Process
-
-1. Update `CHANGELOG.md` (use `git cliff --unreleased` to generate entries)
-2. Update version in `package.json`
-3. Build and test: `make rebuild && make check`
-4. Test locally: `make install-vsix`
-5. Commit changes: `git commit -am "chore: release v<version>"`
-6. Create signed tag: `git tag -a v<version> -m v<version> -s`
-7. Push with tags: `git push --follow-tags`
-8. Publish to Marketplace: `npx vsce publish`
-9. Create GitHub release from the tag
-
-## File Structure Overview
-
-```text
-├── .github/           # GitHub configuration
-├── .vscode/           # VSCode workspace configuration
-├── src/
-│   ├── extension.ts   # Main extension code
-│   └── test/          # Test files
-├── dist/              # Build output (production)
-├── out/               # TypeScript output (tests)
-├── package.json       # Project manifest and scripts
-├── tsconfig.json      # TypeScript configuration
-├── eslint.config.mjs  # Linting rules
-├── esbuild.js         # Build configuration
-└── Makefile           # Build automation, VSIX packaging, git hooks
-```
-
-## Documentation Maintenance
-
-### Keeping README.md Accurate
-
-The `README.md` file is user-facing and should remain stable. However, if any information in `README.md` becomes inaccurate (e.g., features change, commands are renamed, or installation steps are updated), **update `README.md` immediately** to reflect the current state of the project.
-
-When updating `README.md`:
-
-- Keep the user-focused tone and simplicity
-- Ensure feature descriptions match actual functionality
-- Verify all links and installation instructions work
-- Update version numbers or compatibility requirements if they change
-
-### Documentation Consistency
-
-This repository maintains multiple documentation files for different audiences:
-
-- `README.md` - User-facing quickstart and features (keep stable, update if inaccurate)
-- `AGENTS.md` - Concise agent-focused workflow guide
-- `CLAUDE.md` - Detailed guidance for Claude Code
-- `.github/copilot-instructions.md` - Comprehensive Copilot context (this file)
-
-All documentation should be kept consistent. When making changes:
-
-1. Update the relevant documentation file(s)
-2. Cross-check that information aligns across all docs
-3. Ensure command examples and architecture descriptions match
-
-## Trust These Instructions
-
-These instructions are comprehensive and tested. Only search for additional information if:
-
-- Commands documented here fail unexpectedly
-- You encounter errors not covered in the "Common Issues" section
-- You need to understand specific implementation details not covered here
-
-The build system is stable and all documented commands work correctly as of the latest repository state.
+- Only search beyond this doc if commands here fail unexpectedly or you hit an unlisted issue. Build system is stable as documented.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,16 +65,30 @@ jobs:
       - name: Run unit tests with coverage
         run: npm run test:coverage
 
+  get-vscode-version:
+    name: Get VSCode version
+    runs-on: ubuntu-latest
+    outputs:
+      min: ${{ steps.version.outputs.min }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Get minimum VSCode version
+        id: version
+        run: |
+          VERSION=$(node -p "require('./package.json').engines.vscode.replace('^', '')")
+          echo "min=$VERSION" >> "$GITHUB_OUTPUT"
+
   e2e-tests:
     name: E2E tests (VSCode ${{ matrix.vscode }})
+    needs: get-vscode-version
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
       fail-fast: true
       matrix:
         vscode:
-          - "1.100.0" # Minimum supported version
-          - "stable" # Latest stable version
+          - ${{ needs.get-vscode-version.outputs.min }}
+          - "stable"
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.vscode-test.e2e.mjs
+++ b/.vscode-test.e2e.mjs
@@ -1,8 +1,13 @@
+import { createRequire } from "module";
 import { defineConfig } from "@vscode/test-cli";
+
+const require = createRequire(import.meta.url);
+const pkg = require("./package.json");
+const minVersion = pkg.engines.vscode.replace("^", "");
 
 export default defineConfig({
   files: ["out/test/e2e/**/*.test.js"],
-  version: "1.100.0",
+  version: minVersion,
   mocha: {
     timeout: 30000,
   },

--- a/.vscode-test.integration.mjs
+++ b/.vscode-test.integration.mjs
@@ -1,8 +1,13 @@
+import { createRequire } from "module";
 import { defineConfig } from "@vscode/test-cli";
+
+const require = createRequire(import.meta.url);
+const pkg = require("./package.json");
+const minVersion = pkg.engines.vscode.replace("^", "");
 
 export default defineConfig({
   files: ["out/test/integration/**/*.test.js"],
-  version: "1.100.0",
+  version: minVersion,
   mocha: {
     timeout: 30000,
   },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,79 +1,45 @@
 # AGENTS.md
 
-This file contains **agent-focused** instructions for working on this repository (build/test/dev workflow, conventions, and key architecture notes).
+This file provides agent-focused instructions for working on this repository. Project-specific details are marked as examples.
 
 For more context, see `README.md`, `CLAUDE.md`, and `.github/copilot-instructions.md` (these documents should be consistent with each other).
 
 ## Project overview
 
-**invisible-squiggles** is a VSCode extension that toggles **error, warning, info, and hint** squiggles for distraction-free coding.
+**Example project**: VSCode extension that toggles error, warning, info, and hint squiggles by setting `workbench.colorCustomizations` colors to `#00000000`.
 
-It works by manipulating VSCode’s `workbench.colorCustomizations` setting to make diagnostic squiggles transparent by setting colors to `#00000000`.
+**Key behavior**:
 
-## Key user-facing behavior
-
-- **Command**: `invisible-squiggles.toggle` (“Toggle Squiggles”) via Command Palette and status bar button (👁️)
-- **Squiggle types**: Hint, Info, Warning, Error
-- **Persistence**: updates are written to **global** settings (`ConfigurationTarget.Global`)
+- Command: `invisible-squiggles.toggle` via Command Palette and status bar (👁️)
+- Squiggle types: Hint, Info, Warning, Error
+- Persistence: global settings (`ConfigurationTarget.Global`)
 
 ## Development commands
 
-Install dependencies:
+Adapt commands to your project structure.
 
 ```bash
-npm install
-```
-
-Type-check + lint + build (development):
-
-```bash
-npm run compile
-```
-
-Production build (optimized bundle):
-
-```bash
-npm run package
-```
-
-Watch mode (TypeScript + ESBuild watchers):
-
-```bash
-npm run watch
-```
-
-Type check only:
-
-```bash
-npm run check-types
-```
-
-Lint only:
-
-```bash
-npm run lint
-```
-
-Run tests:
-
-```bash
-npm test
+npm install          # Install dependencies
+npm run compile      # Type-check + lint + build (dev)
+npm run package      # Production build (optimized bundle)
+npm run watch        # Watch mode (TypeScript + ESBuild)
+npm run check-types  # Type check only
+npm run lint         # Lint only
+npm test             # Run all tests
 ```
 
 **Note**: Unit tests (`npm run test:unit`) run without VSCode and work in CI. Integration and E2E tests require the VSCode runtime.
 
 ### Testing Infrastructure
 
-The project includes comprehensive testing infrastructure:
+**Example test types**:
 
-**Test Types**:
+- **Unit tests** (`npm run test:unit`): Fast (< 5s), mocked APIs, located in `src/test/unit/`
+- **Integration tests** (`npm run test:integration`): Real APIs, located in `src/test/integration/`
+- **E2E tests** (`npm run test:e2e`): Extension Development Host, located in `src/test/e2e/`
+- **Coverage** (`npm run test:coverage`): Coverage reports with threshold warnings
 
-- **Unit tests** (`npm run test:unit`): Fast tests (< 5 seconds) with mocked VSCode APIs, located in `src/test/unit/`
-- **Integration tests** (`npm run test:integration`): Tests with real VSCode APIs, located in `src/test/integration/`
-- **E2E tests** (`npm run test:e2e`): Full Extension Development Host tests, located in `src/test/e2e/`
-- **Coverage** (`npm run test:coverage`): Generates coverage reports with per-metric threshold warnings
-
-**Test Structure**:
+**Example structure**:
 
 ```tree
 src/test/
@@ -83,53 +49,49 @@ src/test/
 └── helpers/           # Test utilities and mocks
 ```
 
-**Running Tests**:
+## Manual verification
 
-- `npm run test:unit` - Run unit tests only (fast, no VSCode required)
-- `npm run test:integration` - Run integration tests (requires VSCode)
-- `npm run test:e2e` - Run E2E tests (requires Extension Development Host)
-- `npm run test:coverage` - Run all tests with coverage report
+Test changes before committing.
 
-## Manual verification (recommended after changes)
+**Example (VSCode extension)**:
 
-- Press `F5` in VSCode to launch an Extension Development Host
-- Run “Toggle Squiggles” (Command Palette: `Ctrl/Cmd+Shift+P`)
-- Verify:
-  - The status bar eye (👁️) appears
-  - Toggling hides/shows configured squiggle types
-- Reload with `Ctrl/Cmd+R` after code changes
+1. Press `F5` to launch Extension Development Host
+2. Run "Toggle Squiggles" (Command Palette: `Ctrl/Cmd+Shift+P`)
+3. Verify status bar icon (👁️) appears and toggling works
+4. Reload with `Ctrl/Cmd+R` after code changes
 
-## Architecture notes (how it works)
+## Architecture notes
 
-- **Main entry point**: `src/extension.ts`
-- The extension:
-  - Reads current `workbench.colorCustomizations`
-  - Stores original squiggle colors in `invisibleSquiggles.originalColors` (JSON string)
-  - Applies transparent colors (`#00000000`) to configured squiggle color keys
-  - Restores original colors when toggled back
+Describe entry points, data flow, and key files.
+
+**Example architecture**:
+
+1. **Entry point**: `src/extension.ts`
+2. Read current `workbench.colorCustomizations`
+3. Store original colors in `invisibleSquiggles.originalColors` (JSON string)
+4. Apply transparent colors (`#00000000`) to configured squiggle color keys
+5. Restore original colors when toggled back
 
 ## Conventions
+
+**Example**:
 
 - **Language**: TypeScript (strict)
 - **Build**: ESBuild bundles to `dist/` (CommonJS; `vscode` is external)
 
 ### Commit Guidelines
 
-Use [Conventional Commits](https://www.conventionalcommits.org/) format:
+Follow project's commit standard.
 
-- **Imperative mood**: "add feature" (not "added feature" or "adds feature")
-- **Lowercase after colon**: first word is typically lowercase
-- **Summary line**: ≤ 50 characters
-- If the body is included:
-  - **Single blank line**: Leave a single blank line between the summary and the body
-  - **Body lines**: ≤ 72 characters
+**Example (Conventional Commits)**:
 
-**Format**: `<type>[optional scope]: <description>`
+- Format: `<type>[optional scope]: <description>`
+- Imperative mood, lowercase after colon, ≤50 char summary
+- Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `build`, `ci`
+- Examples: `refactor!: consolidate redundant configurations`, `fix: restore colors after multiple toggles`, `docs(README.md): describe keyboard shortcuts`
 
-**Types**: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `build`, `ci`
+## Guidance
 
-**Examples**:
-
-- `refactor!: consolidate redundant configurations`
-- `fix: restore colors after multiple toggles`
-- `docs(README.md): describe keyboard shortcuts`
+- Use explicit, structured instructions with absolute file paths
+- Cite code with line numbers when referencing existing code
+- Keep instructions concise to preserve context window

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,7 +121,7 @@ Use [Conventional Commits](https://www.conventionalcommits.org/) format:
 - **Lowercase after colon**: first word is typically lowercase
 - **Summary line**: ≤ 50 characters
 - If the body is included:
-  - \*\*
+  - **Single blank line**: Leave a single blank line between the summary and the body
   - **Body lines**: ≤ 72 characters
 
 **Format**: `<type>[optional scope]: <description>`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,4 +112,24 @@ src/test/
 
 - **Language**: TypeScript (strict)
 - **Build**: ESBuild bundles to `dist/` (CommonJS; `vscode` is external)
-- **Commits**: Conventional Commits (examples: `feat: ...`, `fix: ...`, `docs: ...`)
+
+### Commit Guidelines
+
+Use [Conventional Commits](https://www.conventionalcommits.org/) format:
+
+- **Imperative mood**: "add feature" (not "added feature" or "adds feature")
+- **Lowercase after colon**: first word is typically lowercase
+- **Summary line**: ≤ 50 characters
+- If the body is included:
+  - \*\*
+  - **Body lines**: ≤ 72 characters
+
+**Format**: `<type>[optional scope]: <description>`
+
+**Types**: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `build`, `ci`
+
+**Examples**:
+
+- `refactor!: consolidate redundant configurations`
+- `fix: restore colors after multiple toggles`
+- `docs(README.md): describe keyboard shortcuts`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com) and this p
 ### 👷 Build
 
 - **(.pre-commit-config.yaml)** reorganize hooks - ([7001d5d](https://github.com/michen00/invisible-squiggles/commit/7001d5db4449bae984182d64636afb9f5fa45d46)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
+- **(CLAUDE.md)** optimize for Claude Code - ([7c05c10](https://github.com/michen00/invisible-squiggles/commit/7c05c107ff391cab8791b9cd3a19272b1880ea32)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
 - **(Makefile)** include omitted hooks - ([50e75ec](https://github.com/michen00/invisible-squiggles/commit/50e75ecf51fcf8adffde80f3e5cc252b9056f9e0)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
+- **(agents)** add commit guidelines - ([4ef7fd0](https://github.com/michen00/invisible-squiggles/commit/4ef7fd04498daf4e425a3612ce6ea6b736f6a8ca)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
+- **(copilot-instructions)** optimize for Copilot - ([a4af884](https://github.com/michen00/invisible-squiggles/commit/a4af884bb3305bc6ddf83fc2a6a5e64ff2db936c)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
 - **(deps-dev)** bump @types/vscode from 1.107.0 to 1.108.0 (#84) - ([f59f24f](https://github.com/michen00/invisible-squiggles/commit/f59f24f88a3297b3919a406dc90a5d7dc0beb35c)) - [dependabot[bot]](mailto:49699333+dependabot[bot]@users.noreply.github.com)
 - **(deps-dev)** bump @typescript-eslint/eslint-plugin - ([16085f3](https://github.com/michen00/invisible-squiggles/commit/16085f317e0db3a22440cb7e365d466a24fcacc7)) - [dependabot[bot]](mailto:49699333+dependabot[bot]@users.noreply.github.com)
 - **(deps-dev)** bump @typescript-eslint/parser from 8.50.1 to 8.51.0 - ([d11bdbb](https://github.com/michen00/invisible-squiggles/commit/d11bdbb5306a04ca6bb9c5b2f431422683fbd409)) - [dependabot[bot]](mailto:49699333+dependabot[bot]@users.noreply.github.com)
@@ -62,12 +65,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com) and this p
 
 ### 📝 Documentation
 
-- **(CHANGELOG.md)** autoupdate Unreleased section - ([60190d8](https://github.com/michen00/invisible-squiggles/commit/60190d80c8e33f20a617e56e4be597bf360908b8)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
+- **(AGENTS.md)** streamline agent instructions - ([a347c8e](https://github.com/michen00/invisible-squiggles/commit/a347c8e15fe8040bb15e39ca71ab650d4a098ec2)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
+- **(CHANGELOG.md)** autoupdate Unreleased section - ([954a4a4](https://github.com/michen00/invisible-squiggles/commit/954a4a4cb685a46c9a0a86ba5f98ae1f5ccc2d8c)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
 - **(CHANGELOG.md)** update for unreleased items - ([7e53637](https://github.com/michen00/invisible-squiggles/commit/7e536370bd6d4419da97257078e54e4350217fdc)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
 - **(CONTRIBUTING.md)** update release instructions - ([2f1584f](https://github.com/michen00/invisible-squiggles/commit/2f1584fde38c8e87ba18af5378365e36573e3474)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
 - **(CONTRIBUTING.md)** improve release guidance - ([e388875](https://github.com/michen00/invisible-squiggles/commit/e38887597f48360ad9eb4d053936ccf6df7c4bc4)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
 - **(README.md)** update problem icons behavior - ([b1ca471](https://github.com/michen00/invisible-squiggles/commit/b1ca4712b9b388c2976eddc731ef65bb6b761960)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
 - **(src/extension.ts)** clarify a comment - ([644161e](https://github.com/michen00/invisible-squiggles/commit/644161e97ee56f6bc4adec34a37bb79bfddf259a)) - [Michael I Chen](mailto:michael.chen.0@gmail.com)
+- clarify commit guidelines for blank lines - ([2718232](https://github.com/michen00/invisible-squiggles/commit/27182320e0e053ed9ecff7427d9939dc8feb8fea)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
 - highlight selective toggle feature details - ([886379f](https://github.com/michen00/invisible-squiggles/commit/886379f14ea877d9a22f4ae031ac2269e49193a4)) - [Michael I Chen](mailto:michael.chen.0@gmail.com)
 - update CHANGELOG - ([3e1f3bb](https://github.com/michen00/invisible-squiggles/commit/3e1f3bb6325a61c06ace0279240b42b82890323f)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
 
@@ -93,6 +98,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com) and this p
 - **(Makefile)** update to match boilerplate - ([6c58415](https://github.com/michen00/invisible-squiggles/commit/6c5841583fe74942804a4637c2fb7ad352f9213a)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
 - **(package.json)** remove a staling comment - ([7212e8f](https://github.com/michen00/invisible-squiggles/commit/7212e8f0cc30b9e98fd8c09e21327fa72d5ab614)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
 - **(src/extension.ts)** revert to a safer type - ([bec9cce](https://github.com/michen00/invisible-squiggles/commit/bec9cce18b47c4d9b277f6b605a6eb7ca547785c)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
+- update .github/copilot-instructions.md - ([b31b8f3](https://github.com/michen00/invisible-squiggles/commit/b31b8f3453cc3d5080146742685b233e78be37f2)) - [Michael I Chen](mailto:michael.chen.0@gmail.com)
+- provide issue templates (#86) - ([281c32a](https://github.com/michen00/invisible-squiggles/commit/281c32a8730eaf9a2f898a03ca65f4cf49fd536a)) - [Michael I Chen](mailto:michael.chen.0@gmail.com)
+- update VSCode version handling - ([9daa8f5](https://github.com/michen00/invisible-squiggles/commit/9daa8f5186e3918505fc658591620c9e609fdf3f)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
 - update VSCode engine version - ([44c1f22](https://github.com/michen00/invisible-squiggles/commit/44c1f2238c97d5451d2c6bb11eed2fcc3acf01b0)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
 - bump a hook version - ([a793b7e](https://github.com/michen00/invisible-squiggles/commit/a793b7e53feb30441febf8e8a617153043c98c1e)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
 - update custom-commit-hooks - ([bd5abff](https://github.com/michen00/invisible-squiggles/commit/bd5abff1636fe1b9d61974c3ee02e512575bf144)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com) and this p
 
 - **(f9a9b25)** use undefined instead of "" - ([65726a8](https://github.com/michen00/invisible-squiggles/commit/65726a82aaa54b50564062ee9ee3e0348b988c76)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
 - **(toggleSquigglesCore)** return isInvisibleState - ([db7cfcd](https://github.com/michen00/invisible-squiggles/commit/db7cfcd3e73095667ad6052fc6c06071bdbb423a)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
+- recover from stuck transparent state - ([824a28a](https://github.com/michen00/invisible-squiggles/commit/824a28a12ac3dbc63b12597e5be37d4406521bee)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
+- clean up settings on shutdown/uninstall - ([d3cdb41](https://github.com/michen00/invisible-squiggles/commit/d3cdb41b6cad320d255535c1aad43f2bfc484717)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
+- preserve partial staging - ([57b08b6](https://github.com/michen00/invisible-squiggles/commit/57b08b6e3df1cce78a253ec1e7a12d0c77abdaff)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
 - enhance toggleSquigglesCore state logic - ([7310e2b](https://github.com/michen00/invisible-squiggles/commit/7310e2b99c3a36212b6ed537cb1c88bce192bb67)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
 - use empty strings instead of nulls (#75) - ([f9a9b25](https://github.com/michen00/invisible-squiggles/commit/f9a9b25800cc1f56a7583977027ec8d4c391ecf4)) - [Michael I Chen](mailto:michael.chen.0@gmail.com)
 
@@ -22,6 +25,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com) and this p
 
 ### 🧪 Testing
 
+- add recovery and JSON primitive tests - ([12825a3](https://github.com/michen00/invisible-squiggles/commit/12825a3dd349a1743f952aedcc3eb6c74ca0244a)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
+- enhance mock config helpers - ([4a4abdb](https://github.com/michen00/invisible-squiggles/commit/4a4abdbff21f4acae1bf560e8418b0c94277e735)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
+- cover the deactivate function - ([2ef2550](https://github.com/michen00/invisible-squiggles/commit/2ef2550d857ca9a3ad8de5a74690ab493172c085)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
+- add unit tests for restoreAndCleanup - ([2f7efbf](https://github.com/michen00/invisible-squiggles/commit/2f7efbfdb41347e17fc434c381df16b49b272728)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
 - add a failing test - ([a569466](https://github.com/michen00/invisible-squiggles/commit/a569466b1b2e978566ab2d2fbc538d8cfde4110d)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
 - refactor toggleSquiggles unit tests - ([51e9d1b](https://github.com/michen00/invisible-squiggles/commit/51e9d1bb368a0a7277d64a115f9529070192a05e)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
 - add unit tests - ([3bb5f12](https://github.com/michen00/invisible-squiggles/commit/3bb5f12582e0b869be871891aa26a0cd2795717e)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
@@ -36,41 +43,49 @@ The format is based on [Keep a Changelog](https://keepachangelog.com) and this p
 - **(.github/workflows/ci.yml)** skip setup-python - ([3d76fad](https://github.com/michen00/invisible-squiggles/commit/3d76fad3f247e2ab0fae10c0a9a0ea7cfa78e838)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
 - **(.github/workflows/ci.yml)** run pre-commit - ([03b10c6](https://github.com/michen00/invisible-squiggles/commit/03b10c6031afdb734f4401b223ccf3745f71e529)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
 - **(pre-commit)** add a workflow for updates - ([8716b67](https://github.com/michen00/invisible-squiggles/commit/8716b6792984d3e258d6123e48a7b1b83a940e76)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
-- add changelog autoupdate workflow - ([1171dbe](https://github.com/michen00/invisible-squiggles/commit/1171dbefb70343bb5a7c9d6d0c892b2e805f89cc)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
+- add changelog autoupdate workflow - ([fd7505c](https://github.com/michen00/invisible-squiggles/commit/fd7505c7bfbe93c90bc854bb5739c1ae34482734)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
 - simplify interaction logic - ([700323d](https://github.com/michen00/invisible-squiggles/commit/700323d09a10ec6661eddca0381822c463b587a9)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
 
 ### 👷 Build
 
 - **(.pre-commit-config.yaml)** reorganize hooks - ([7001d5d](https://github.com/michen00/invisible-squiggles/commit/7001d5db4449bae984182d64636afb9f5fa45d46)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
 - **(Makefile)** include omitted hooks - ([50e75ec](https://github.com/michen00/invisible-squiggles/commit/50e75ecf51fcf8adffde80f3e5cc252b9056f9e0)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
+- **(deps-dev)** bump @types/vscode from 1.107.0 to 1.108.0 (#84) - ([f59f24f](https://github.com/michen00/invisible-squiggles/commit/f59f24f88a3297b3919a406dc90a5d7dc0beb35c)) - [dependabot[bot]](mailto:49699333+dependabot[bot]@users.noreply.github.com)
+- **(deps-dev)** bump @typescript-eslint/eslint-plugin - ([16085f3](https://github.com/michen00/invisible-squiggles/commit/16085f317e0db3a22440cb7e365d466a24fcacc7)) - [dependabot[bot]](mailto:49699333+dependabot[bot]@users.noreply.github.com)
 - **(deps-dev)** bump @typescript-eslint/parser from 8.50.1 to 8.51.0 - ([d11bdbb](https://github.com/michen00/invisible-squiggles/commit/d11bdbb5306a04ca6bb9c5b2f431422683fbd409)) - [dependabot[bot]](mailto:49699333+dependabot[bot]@users.noreply.github.com)
 - **(deps-dev)** bump @typescript-eslint/eslint-plugin from 8.50.1 to 8.51.0 (#71) - ([82e2e4d](https://github.com/michen00/invisible-squiggles/commit/82e2e4d2dc0bdada198efe2ecc686d1057f27fdb)) - [dependabot[bot]](mailto:49699333+dependabot[bot]@users.noreply.github.com)
 - **(deps-dev)** bump qs in the npm_and_yarn group across 1 directory (#70) - ([6b4cc65](https://github.com/michen00/invisible-squiggles/commit/6b4cc65a62e472977172e2cfe4c24c931994c288)) - [dependabot[bot]](mailto:49699333+dependabot[bot]@users.noreply.github.com)
-- **(deps-dev)** bump @typescript-eslint/eslint-plugin - ([9346e16](https://github.com/michen00/invisible-squiggles/commit/9346e1660ef5d14a2fb8eb53634950273874413e)) - [dependabot[bot]](mailto:49699333+dependabot[bot]@users.noreply.github.com)
 - **(deps-dev)** bump @typescript-eslint/parser from 8.50.0 to 8.50.1 - ([7fc95b9](https://github.com/michen00/invisible-squiggles/commit/7fc95b929ae62580d1f12c86f92d659f895e018e)) - [dependabot[bot]](mailto:49699333+dependabot[bot]@users.noreply.github.com)
-- add a changelog helper - ([63b9ce9](https://github.com/michen00/invisible-squiggles/commit/63b9ce9a59161f1cd1fb9905fdaa9b7272635ec3)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
+- add a changelog helper - ([d118142](https://github.com/michen00/invisible-squiggles/commit/d118142d974e5dde46b9bf182d6ead3f67ff22d7)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
 - mark additional dependencies as peer - ([33c8612](https://github.com/michen00/invisible-squiggles/commit/33c8612782f7e699c19eb7c2422286549cbeb135)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
 - remove an unused extension - ([caaa2a4](https://github.com/michen00/invisible-squiggles/commit/caaa2a4a779f47fab1d6b3b0f7ef4e59256b07a2)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
 
 ### 📝 Documentation
 
-- **(CHANGELOG.md)** autoupdate Unreleased section - ([1371808](https://github.com/michen00/invisible-squiggles/commit/1371808e3268d48359ab9ab6bfcac7839c563116)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
+- **(CHANGELOG.md)** autoupdate Unreleased section - ([60190d8](https://github.com/michen00/invisible-squiggles/commit/60190d80c8e33f20a617e56e4be597bf360908b8)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
 - **(CHANGELOG.md)** update for unreleased items - ([7e53637](https://github.com/michen00/invisible-squiggles/commit/7e536370bd6d4419da97257078e54e4350217fdc)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
-- **(CONTRIBUTING.md)** update release instructions - ([2e4b9b5](https://github.com/michen00/invisible-squiggles/commit/2e4b9b504203ccbe28439dba6c5d4bcc46b6f7b6)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
+- **(CONTRIBUTING.md)** update release instructions - ([2f1584f](https://github.com/michen00/invisible-squiggles/commit/2f1584fde38c8e87ba18af5378365e36573e3474)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
 - **(CONTRIBUTING.md)** improve release guidance - ([e388875](https://github.com/michen00/invisible-squiggles/commit/e38887597f48360ad9eb4d053936ccf6df7c4bc4)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
 - **(README.md)** update problem icons behavior - ([b1ca471](https://github.com/michen00/invisible-squiggles/commit/b1ca4712b9b388c2976eddc731ef65bb6b761960)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
 - **(src/extension.ts)** clarify a comment - ([644161e](https://github.com/michen00/invisible-squiggles/commit/644161e97ee56f6bc4adec34a37bb79bfddf259a)) - [Michael I Chen](mailto:michael.chen.0@gmail.com)
-- update CHANGELOG - ([d325949](https://github.com/michen00/invisible-squiggles/commit/d3259498f880c9e184f000bcfe4120e9a190fbe6)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
+- highlight selective toggle feature details - ([886379f](https://github.com/michen00/invisible-squiggles/commit/886379f14ea877d9a22f4ae031ac2269e49193a4)) - [Michael I Chen](mailto:michael.chen.0@gmail.com)
+- update CHANGELOG - ([3e1f3bb](https://github.com/michen00/invisible-squiggles/commit/3e1f3bb6325a61c06ace0279240b42b82890323f)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
 
 ### ♻️ Refactor
 
-- streamline the script - ([1276c83](https://github.com/michen00/invisible-squiggles/commit/1276c83ea0d5f4af1f3636f0bbb7168a0bbbbc21)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
+- simplify invisible state detection - ([7e3327c](https://github.com/michen00/invisible-squiggles/commit/7e3327c4fd410adfd697426afbcbdc2407542490)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
+- streamline the script - ([289b62e](https://github.com/michen00/invisible-squiggles/commit/289b62e4bd85390323ba8f17f5110edc3fe75525)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
 - update E2E tests and avoid redundancy - ([7082072](https://github.com/michen00/invisible-squiggles/commit/708207286a929cac2273ddf60ec0d10ea50a87f4)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
 - exit on error instead of warning - ([27ff320](https://github.com/michen00/invisible-squiggles/commit/27ff32072fd23270b61893284ea1f81dd5803eb9)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
+
+### 🎨 Styling
+
+- **(src/extension.ts)** add a line break - ([a150fa9](https://github.com/michen00/invisible-squiggles/commit/a150fa92d545c291b80e94d50d1a6466c69bc908)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
 
 ### ⚙️ Miscellaneous Tasks
 
 - **(.editorconfig)** remove an invalid key - ([be54bd1](https://github.com/michen00/invisible-squiggles/commit/be54bd18f41d9634d03efa931d464d695490328f)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
+- **(.gitlint)** ignore by title - ([61aa749](https://github.com/michen00/invisible-squiggles/commit/61aa74930eb808796a65151506fd56f3660d2bfa)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
 - **(.pre-commit-config.yaml)** update hooks - ([7e0053a](https://github.com/michen00/invisible-squiggles/commit/7e0053abc2fd2b489b9524a63312667a24934256)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
 - **(.yamllint)** drop yamlfmt - ([f23956d](https://github.com/michen00/invisible-squiggles/commit/f23956d6e5c4f2026a511aa4657ab80fa7a61f96)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
 - **(Makefile)** improve the portability of colors - ([9802145](https://github.com/michen00/invisible-squiggles/commit/9802145aad6ffe9fd7c6a655430631d34a9e8d3f)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
@@ -78,8 +93,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com) and this p
 - **(Makefile)** update to match boilerplate - ([6c58415](https://github.com/michen00/invisible-squiggles/commit/6c5841583fe74942804a4637c2fb7ad352f9213a)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
 - **(package.json)** remove a staling comment - ([7212e8f](https://github.com/michen00/invisible-squiggles/commit/7212e8f0cc30b9e98fd8c09e21327fa72d5ab614)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
 - **(src/extension.ts)** revert to a safer type - ([bec9cce](https://github.com/michen00/invisible-squiggles/commit/bec9cce18b47c4d9b277f6b605a6eb7ca547785c)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
-- clarify commit message - ([78182fa](https://github.com/michen00/invisible-squiggles/commit/78182fad942ab3a84f0102b7828be2b7b9096330)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
-- update .gitignore - ([77d415e](https://github.com/michen00/invisible-squiggles/commit/77d415eb6b25a458e78b6fa016ff16985a0d9bfa)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
+- update VSCode engine version - ([44c1f22](https://github.com/michen00/invisible-squiggles/commit/44c1f2238c97d5451d2c6bb11eed2fcc3acf01b0)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
+- bump a hook version - ([a793b7e](https://github.com/michen00/invisible-squiggles/commit/a793b7e53feb30441febf8e8a617153043c98c1e)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
+- update custom-commit-hooks - ([bd5abff](https://github.com/michen00/invisible-squiggles/commit/bd5abff1636fe1b9d61974c3ee02e512575bf144)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
+- quote variable expansion - ([1b8c8ec](https://github.com/michen00/invisible-squiggles/commit/1b8c8ec376066e7d2d556721fd7202e5e3e85162)) - [Michael I Chen](mailto:michael.chen.0@gmail.com)
+- clarify commit message - ([4c28988](https://github.com/michen00/invisible-squiggles/commit/4c289880ed421e918dbd327723d6fa03ba9fe9c2)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
+- update .gitignore - ([19375f9](https://github.com/michen00/invisible-squiggles/commit/19375f9c2592656f4678231108d53cdfd587cb76)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
 - autoupdate pre-commit hooks - ([2c879f8](https://github.com/michen00/invisible-squiggles/commit/2c879f8a3491fac3fe3ca410f8b65f60e635f768)) - [pre-commit-ci[bot]](mailto:66853113+pre-commit-ci[bot]@users.noreply.github.com)
 - remove a python-specific pre-commit hook - ([39fe15d](https://github.com/michen00/invisible-squiggles/commit/39fe15dff3a3b1e99145044d0aaed6e38a40de9c)) - [Michael I Chen](mailto:michael.chen@aicadium.ai)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,19 +114,30 @@ Important: All color updates use `ConfigurationTarget.Global` to affect all work
 
 ## Commit Guidelines
 
-Use Conventional Commits format:
+Use [Conventional Commits](https://www.conventionalcommits.org/) format:
 
 ```text
 <type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
 ```
 
-Common types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `build`, `ci`
+**Rules**:
 
-Examples:
+- **Imperative mood**: "add feature" not "added feature" or "adds feature"
+- **Lowercase after colon**: first word is lowercase unless a proper noun (e.g., `feat: add ESLint rule`)
+- **Summary line**: ≤ 50 characters
+- **Body lines**: ≤ 72 characters (wrap longer explanations)
 
-- `feat: add command for selective squiggle type toggling`
-- `fix: restore original colors correctly after multiple toggles`
-- `docs: update README with keyboard shortcut instructions`
+**Types**: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `build`, `ci`
+
+**Examples**:
+
+- `refactor!: consolidate redundant configurations`
+- `fix: restore colors after multiple toggles`
+- `docs(README.md): describe keyboard shortcuts`
 
 ## Release Process
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "typescript": "^5.9.3"
       },
       "engines": {
-        "vscode": "^1.100.0"
+        "vscode": "^1.108.0"
       }
     },
     "node_modules/@azu/format-text": {
@@ -1545,6 +1545,7 @@
       "integrity": "sha512-iIACsx8pxRnguSYhHiMn2PvhvfpopO9FXHyn1mG5txZIsAaB6F0KwbFnUQN3KCiG3Jcuad/Cao2FAs1Wp7vAyg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.52.0",
         "@typescript-eslint/types": "8.52.0",
@@ -2130,6 +2131,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3532,6 +3534,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8109,6 +8112,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8315,6 +8319,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "onStartupFinished"
   ],
   "engines": {
-    "vscode": "^1.100.0"
+    "vscode": "^1.108.0"
   },
   "main": "./dist/extension.js",
   "contributes": {


### PR DESCRIPTION
basically just updated a lot of docs

---

<!-- Summary added after merge. Original description above is unchanged. -->

### What this branch ended up containing

Added retrospectively: this branch grew well past its original description during review, and the summary below is reconstructed from the merged diff.

Opened as "basically just updated a lot of docs". **12 commits across 9 files**, and the docs were the smaller half.

- Contributor and agent documentation: `AGENTS.md`, `CLAUDE.md`, `.github/copilot-instructions.md`
- `CHANGELOG.md` prepared for release
- `ci.yml` and the `.vscode-test.*.mjs` harness configs adjusted
- `package.json` and `package-lock.json` updated

No version bump — that came in #89.
