### PR TITLE
ci: greet only genuine newcomers

### DIFF
--- a/.github/workflows/greet-new-contributors.yml
+++ b/.github/workflows/greet-new-contributors.yml
@@ -18,8 +18,15 @@ jobs:
       - name: detect bot author
         id: bot-author-check
         uses: ./.github/actions/detect-bot-author
+      # Greet genuine newcomers only: the bot guard handles automation;
+      # author_association skips maintainers and returning contributors,
+      # whose first-interaction count is unreliable during PR bursts.
       - name: greet first interactions
-        if: steps.bot-author-check.outputs.is-bot == 'false'
+        if: >-
+          steps.bot-author-check.outputs.is-bot == 'false' &&
+          !contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'),
+          github.event.pull_request.author_association ||
+          github.event.issue.author_association)
         uses: actions/first-interaction@v3
         with:
           issue_message: |


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

CI: greet only genuine newcomers by guarding on author_association
<code>🐞 Bug fix</code> <code>⚙️ Configuration changes</code> <code>🕐 Less than 10 minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

## What

Adds an `author_association` guard to the greet step in [`greet-new-contributors.yml`](.github/workflows/greet-new-contributors.yml) so the greeting fires **only for genuine newcomers**, skipping `OWNER`, `MEMBER`, `COLLABORATOR`, and `CONTRIBUTOR`:

```yaml
if: >-
  steps.bot-author-check.outputs.is-bot == 'false' &&
  !contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'),
  github.event.pull_request.author_association ||
  github.event.issue.author_association)
```

## Why

`actions/first-interaction`'s first-timer detection is unreliable during rapid PR bursts (GitHub's search index lags, so each new PR can look like the author's "first"), which lets it welcome maintainers and returning contributors. The bot guard (#49) already stops automation — on this repo the only greetings ever recorded went to `pre-commit-ci[bot]` (#47, #48), pre-#49. This is **preventive hardening** for the maintainer/returnee case, mirroring [`michen00/boilerplate-sync#107`](https://github.com/michen00/boilerplate-sync/pull/107), where the greeter had welcomed the repo owner.

## Verification

- `actionlint` validates the `if:` expression; yamllint clean.
- Behavior is verified live on the **first PR after merge** — `pull_request` workflows run from the base branch, so the guard can't be exercised on its own PR.

## Files touched

- `.github/workflows/greet-new-contributors.yml`

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Restrict the greeter to non-bot authors who are not maintainers/returning contributors.
• Prevent false “first interaction” greetings during rapid PR bursts when GitHub indexing lags.
• Document the rationale directly in the workflow step comments.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  A["PR/Issue event"] --> B["Workflow job"] --> C["Detect bot author"] --> D{"Guard checks"} --> E["actions/first-interaction"]
  D -->|"is-bot == false"| D
  D -->|"assoc allowed"| E
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Allowlist newcomer associations</b></summary>

- ➕ Safer against new/unknown association values (defaults to not greeting)
- ➕ More explicit intent (e.g., allow only FIRST_TIME_CONTRIBUTOR/FIRST_TIMER/NONE)
- ➖ May miss legitimate newcomers if GitHub introduces/uses additional newcomer-like values
- ➖ Requires confirming the full set of ‘newcomer’ associations for all event types used

</details>

<details>
<summary><b>2. Replace first-interaction with an API-based history check</b></summary>

- ➕ Avoids GitHub search index lag; can deterministically query prior PRs/issues
- ➕ More controllable logic and edge-case handling
- ➖ More code/maintenance and likely requires scripting + API pagination
- ➖ Higher rate-limit and auth/token considerations

</details>

**Recommendation:** The current approach is a pragmatic hardening with minimal blast radius: keep it. If this workflow becomes sensitive to edge cases, consider switching from a denylist to an allowlist of explicit newcomer associations to make the default behavior conservative.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Other</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>greet-new-contributors.yml</strong> <code>Gate greeter on author_association to avoid greeting maintainers/returnees</code> <code>+8/-1</code></summary>

<br/>

>Gate greeter on author_association to avoid greeting maintainers/returnees
>
><pre>
>• Adds an author_association-based condition to the greet step, in addition to the existing bot-author guard. Also documents why the guard is necessary (first-interaction can mis-detect first timers during PR bursts).
></pre>
>
><a href='https://github.com/michen00/invisible-squiggles/pull/195/files#diff-ecc08c266c2cd109ee5414d0935b11996fb4295da0e44ae743424c8194ff52f0'>.github/workflows/greet-new-contributors.yml</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>