### PR TITLE
ci: package the vsix on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,8 +102,13 @@ jobs:
           cache: npm
       - name: Install dependencies
         run: npm ci
-      - name: Package VSIX
-        run: make build-vsix
+      # `verify-reproducible`, not `build-vsix`: build-vsix depends on `install`,
+      # which would re-run `npm install` on top of the `npm ci` above, and it
+      # packages only once. This packages twice under different umasks and fails
+      # if the two disagree, so the invariant the publish retry path depends on is
+      # checked on every PR rather than first exercised on a tagged release.
+      - name: Package VSIX and verify reproducibility
+        run: make verify-reproducible
       # Lets a reviewer install the exact build from a PR before merging.
       - name: Upload VSIX
         uses: actions/upload-artifact@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,37 @@ jobs:
           files: coverage/lcov.info
           fail_ci_if_error: false
 
+  # Packaging is the only step that exercises vsce, and nothing else in CI ran
+  # it. That let two whole classes of breakage reach main unnoticed:
+  #   - manifest drift: vsce refuses to package when @types/vscode declares a
+  #     version above engines.vscode, which a dependabot bump silently caused
+  #   - Git LFS pointers reaching vsce: it packages a 130-byte pointer file
+  #     without warning, shipping an extension whose icon is ASCII text
+  # Neither is visible to type-checking, linting, or the test suites.
+  package:
+    name: Package VSIX
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22.x
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Package VSIX
+        run: make build-vsix
+      # Lets a reviewer install the exact build from a PR before merging.
+      - name: Upload VSIX
+        uses: actions/upload-artifact@v7
+        with:
+          name: vsix
+          path: ./*.vsix
+          if-no-files-found: error
+
   get-vscode-version:
     name: Get VSCode version
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds a `Package VSIX` job to CI, so pull requests actually build the extension.

> Body rewritten after merge for accuracy: the job as merged runs `make verify-reproducible`, not `make build-vsix` as originally described.

## Why

Packaging was the only step that exercised `vsce`, and nothing in CI ran it. That let two classes of breakage reach `main` unnoticed, both of which had actually happened:

**Manifest drift.** `vsce` refuses to package when `@types/vscode` declares a version above the `engines.vscode` floor. A Dependabot bump did exactly that — `make build-vsix` and `make publish` were both dead on `main` while every check stayed green.

**Git LFS pointers.** `vsce` packages a 130-byte pointer file without warning, shipping an extension whose icon is ASCII text rather than an image.

Neither is visible to type-checking, linting, or either test suite. Only running `vsce` catches them.

## What the job does

After `npm ci`, it runs `make verify-reproducible`, which packages the extension **twice under different umasks** and fails if the two builds differ. That covers plain packaging and additionally guards the byte-reproducibility that the publish workflow's retry path depends on — see #228. Previously that guarantee was first exercised on a tagged release, which is a poor place to discover it is broken.

`make verify-reproducible` rather than `make build-vsix` for a second reason: `build-vsix` depends on the `install` target, which would re-run `npm install` on top of the `npm ci` above it.

The resulting `.vsix` is uploaded as a build artifact, so a reviewer can install the exact build from a pull request before merging it.

## Note on this pull request's own history

This branch was originally opened against a feature branch rather than `main`. Because `ci.yml` filters `pull_request` on `branches: [main]`, none of its own checks ran while that was the case. It was rebuilt on `main`, at which point CI ran for the first time — including this new job, which passed.
