### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes will be documented in this file. See [conventional commits](
 
 The format is based on [Keep a Changelog](https://keepachangelog.com) and this project adheres to [Semantic Versioning](https://semver.org).
 
-## [Unreleased]
+## [0.4.0](https://github.com/michen00/invisible-squiggles/compare/v0.3.1..v0.4.0) - 2026-07-30
 
 ### ✨ Features
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "invisible-squiggles",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "invisible-squiggles",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "SEE LICENSE IN LICENSE",
       "devDependencies": {
         "@types/mocha": "^10.0.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "invisible-squiggles",
   "displayName": "invisible squiggles",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "publisher": "michen00",
   "description": "toggle the transparency of diagnostic squiggles for distraction-free coding",
   "author": {


### PR DESCRIPTION
Prepares the v0.4.0 release. Three files, four lines, no code changes.

- `CHANGELOG.md`: the `Unreleased` heading becomes `## [0.4.0](https://github.com/michen00/invisible-squiggles/compare/v0.3.1..v0.4.0) - 2026-07-30`
- `package.json` and `package-lock.json`: 0.3.1 → 0.4.0

The changelog entries themselves are unchanged. Re-running `make update-unreleased` reports "already up-to-date", so what is committed is exactly what `git-cliff` generates.

## Why 0.4.0

`git-cliff --bumped-version` computes `v0.4.0` on its own from the `[bump]` configuration. Three `feat:` commits have been waiting since v0.3.1 (2026-01-11): the `startHidden` setting, the optimised icon, and the improved fallback.

## Why the release pipeline work is not in the changelog

`cliff.toml` skips `ci:` commits, and the pull requests that built the release pipeline (#228, #229) were squash-merged with `ci:` subjects, so nothing from them appears. That is the configured behaviour. Note the squash also discarded the individual `fix:` commits inside those branches, which would otherwise have been listed.

Coverage is not lost. `make release` passes `--generate-notes`, and `.github/release.yml` filters only bot authors, so both pull requests appear by title in the GitHub release notes. Availability on Open VSX is advertised in `README.md`.

## After merging

This is the first release to run the publish workflow end to end, and the first version published to Open VSX.

```sh
git switch main && git pull
git tag -a v0.4.0 -m v0.4.0 -s     # -s is required; tag.gpgsign is not set
make verify-tag VERSION=v0.4.0
git push --follow-tags
make release VERSION=v0.4.0
```

Tag promptly after merging. Until the tag exists, `git-cliff` still counts these commits as unreleased, so the scheduled changelog job would open a pull request duplicating the 0.4.0 section.

## Verified

`make check` passes — 100 unit, 9 integration and 2 E2E tests, plus both shell suites. `make verify-reproducible` passes at the new version, and the artifact is named `invisible-squiggles-0.4.0.vsix`, confirming the version bump is picked up by the packaging path.
