### PR TITLE
ci: harden bot auto-merge against actor drift

### DIFF
--- a/.github/workflows/bot-automerge-disarm.yml
+++ b/.github/workflows/bot-automerge-disarm.yml
@@ -47,14 +47,20 @@ jobs:
       # on, so a --disable-auto that reported success without taking effect is caught.
       - name: Disarm auto-merge
         run: |
-          state=$(gh pr view "$PR_NUMBER" --json state --jq .state 2>/dev/null || echo "")
+          # An unreadable state falls through to the disarm loop rather than exiting, so
+          # the fallback here is the safe direction. stderr stays visible: only a
+          # confirmed CLOSED or MERGED short-circuits.
+          state=$(gh pr view "$PR_NUMBER" --json state --jq .state || echo "")
           if [ "$state" = "CLOSED" ] || [ "$state" = "MERGED" ]; then
             echo "::notice::PR #${PR_NUMBER} is ${state}; nothing to disarm."
             exit 0
           fi
           for attempt in 1 2 3; do
+            # stderr is left visible on purpose: this probe is allowed to fail (the
+            # disable below runs regardless), but a silent failure would hide why a
+            # disarm needed three attempts.
             armed=$(gh pr view "$PR_NUMBER" --json autoMergeRequest \
-              --jq '.autoMergeRequest != null' 2>/dev/null) || armed=""
+              --jq '.autoMergeRequest != null') || armed=""
             if [ "$armed" = "false" ]; then
               echo "::notice::Auto-merge is off on PR #${PR_NUMBER}."
               exit 0

--- a/.github/workflows/bot-automerge-disarm.yml
+++ b/.github/workflows/bot-automerge-disarm.yml
@@ -59,9 +59,12 @@ jobs:
               echo "::notice::Auto-merge is off on PR #${PR_NUMBER}."
               exit 0
             fi
-            if [ "$armed" = "true" ]; then
-              gh pr merge --disable-auto "$PR_NUMBER" || true
-            fi
+            # Attempt the disable whenever "off" was not positively confirmed, which
+            # includes the probe itself having failed and left $armed empty. Only
+            # confirmed-off exits above. Gating this on "true" would mean a transient API
+            # error skipped the attempt entirely and left the PR armed -- the outcome
+            # this workflow exists to prevent.
+            gh pr merge --disable-auto "$PR_NUMBER" || true
             echo "::warning::attempt ${attempt}: auto-merge not yet confirmed off on #${PR_NUMBER}."
             sleep 5
           done

--- a/.github/workflows/bot-automerge-disarm.yml
+++ b/.github/workflows/bot-automerge-disarm.yml
@@ -1,0 +1,70 @@
+---
+name: Bot auto-merge disarm
+
+# The half that makes arming defensible. bot-automerge.yml arms GitHub's native
+# auto-merge with no human action, and that has to be revocable: a label that cannot
+# take the merge back is a one-way door, and the margin it removes is the one a mistake
+# needs.
+#
+# Gating the arming job on the label is not enough. Once auto-merge is enabled it lives
+# server-side, so a label applied afterwards stops the workflow from running again while
+# GitHub still merges the moment requirements pass. Something has to actively turn it off.
+#
+# No branch filter and no fork guard, deliberately. A suppressor must be at least as
+# broad as the thing it suppresses, and disarming a pull request that was never armed is
+# a no-op -- so the cheap failure is running when it need not, and the expensive one is
+# declining to run when it should.
+
+on:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  # Keyed on the label as well as the number: a disarm must not be cancelled by a
+  # different label event arriving on the same pull request.
+  group: bot-automerge-disarm-${{ github.event.pull_request.number }}-${{ github.event.label.name }}
+  cancel-in-progress: false
+
+jobs:
+  disarm:
+    if: github.event.label.name == 'do not auto-merge'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+    steps:
+      # Fails closed. A pull request whose state cannot be read is treated as one that
+      # should not stay armed: disarming one that was never armed is a no-op, whereas
+      # leaving one armed on a failed probe is the outcome with a cost.
+      #
+      # Verified rather than trusted: each attempt re-reads whether auto-merge is still
+      # on, so a --disable-auto that reported success without taking effect is caught.
+      - name: Disarm auto-merge
+        run: |
+          state=$(gh pr view "$PR_NUMBER" --json state --jq .state 2>/dev/null || echo "")
+          if [ "$state" = "CLOSED" ] || [ "$state" = "MERGED" ]; then
+            echo "::notice::PR #${PR_NUMBER} is ${state}; nothing to disarm."
+            exit 0
+          fi
+          for attempt in 1 2 3; do
+            armed=$(gh pr view "$PR_NUMBER" --json autoMergeRequest \
+              --jq '.autoMergeRequest != null' 2>/dev/null) || armed=""
+            if [ "$armed" = "false" ]; then
+              echo "::notice::Auto-merge is off on PR #${PR_NUMBER}."
+              exit 0
+            fi
+            if [ "$armed" = "true" ]; then
+              gh pr merge --disable-auto "$PR_NUMBER" || true
+            fi
+            echo "::warning::attempt ${attempt}: auto-merge not yet confirmed off on #${PR_NUMBER}."
+            sleep 5
+          done
+          echo "::error::Could not confirm auto-merge is off on #${PR_NUMBER}. Disable it by hand:"
+          echo "::error::gh pr merge --disable-auto ${PR_NUMBER} --repo ${GH_REPO}"
+          exit 1

--- a/.github/workflows/bot-automerge.yml
+++ b/.github/workflows/bot-automerge.yml
@@ -45,8 +45,10 @@ jobs:
   bot-automerge:
     # `do not auto-merge` is the kill switch, and this is the path that needs one:
     # arming takes no human action, so without a label there is nothing to withhold.
-    # The workflow re-runs on labeled and unlabeled, so applying the label mid-flight
-    # re-evaluates and stops arming.
+    #
+    # This check alone only stops the job from arming again. Auto-merge already enabled
+    # lives server-side, so a label applied afterwards would not turn it off --
+    # bot-automerge-disarm.yml does that, and is the half that makes arming defensible.
     if: >-
       github.event.pull_request.head.repo.full_name == github.repository &&
       (github.event.pull_request.user.login == 'dependabot[bot]' ||
@@ -56,6 +58,7 @@ jobs:
     timeout-minutes: 10
     env:
       GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
       PR_URL: ${{ github.event.pull_request.html_url }}
     steps:
       # No checkout step: nothing below reads the repository.
@@ -84,7 +87,25 @@ jobs:
         env:
           AUTHOR: ${{ github.event.pull_request.user.login }}
           UPDATE_TYPE: ${{ steps.meta.outputs.update-type }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
+          # Keying on the PR author is what makes the guard survive later pushes by other
+          # identities, but on its own it would also let anything pushed onto a bot's
+          # branch inherit the bot's eligibility -- a collaborator could land arbitrary
+          # code through a path that approves and merges itself. Require every commit to
+          # be the bot's own. An unreadable or unmatched author counts as foreign, so the
+          # probe fails closed.
+          foreign=0
+          logins=$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}/commits" --paginate \
+            --jq '.[].author.login // "UNKNOWN"' 2>/dev/null || echo UNKNOWN)
+          while IFS= read -r login; do
+            [ "$login" = "$AUTHOR" ] || foreign=$((foreign + 1))
+          done <<< "$logins"
+          if [ "$foreign" -ne 0 ]; then
+            echo "::warning::${foreign} commit(s) not authored by ${AUTHOR}; holding."
+            echo "should_merge=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           if [ "$AUTHOR" = "pre-commit-ci[bot]" ]; then
             echo "::notice::pre-commit-ci hook bump; eligible for auto-merge."
             echo "should_merge=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/bot-automerge.yml
+++ b/.github/workflows/bot-automerge.yml
@@ -95,12 +95,32 @@ jobs:
           # code through a path that approves and merges itself. Require every commit to
           # be the bot's own. An unreadable or unmatched author counts as foreign, so the
           # probe fails closed.
+          # Emits a sentinel rather than an empty string for an unlinked author: command
+          # substitution strips trailing newlines, so a null author on the final commit
+          # would vanish before the loop counted it and the guard would pass.
+          if ! logins=$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}/commits" --paginate \
+              --jq '.[].author.login // "<none>"' 2>/dev/null); then
+            echo "::warning::Could not read commit authors for #${PR_NUMBER}; holding."
+            echo "should_merge=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Counted apart so the reason is accurate: an unlinked author is not the same
+          # finding as a commit by somebody else, and reporting either as the other sends
+          # whoever reads the log looking in the wrong place.
           foreign=0
-          logins=$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}/commits" --paginate \
-            --jq '.[].author.login // "UNKNOWN"' 2>/dev/null || echo UNKNOWN)
+          unlinked=0
           while IFS= read -r login; do
-            [ "$login" = "$AUTHOR" ] || foreign=$((foreign + 1))
+            if [ -z "$login" ] || [ "$login" = "<none>" ]; then
+              unlinked=$((unlinked + 1))
+            elif [ "$login" != "$AUTHOR" ]; then
+              foreign=$((foreign + 1))
+            fi
           done <<< "$logins"
+          if [ "$unlinked" -ne 0 ]; then
+            echo "::warning::${unlinked} commit(s) with no linked GitHub author; holding."
+            echo "should_merge=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           if [ "$foreign" -ne 0 ]; then
             echo "::warning::${foreign} commit(s) not authored by ${AUTHOR}; holding."
             echo "should_merge=false" >> "$GITHUB_OUTPUT"
@@ -131,6 +151,19 @@ jobs:
             gh pr review --approve "$PR_URL"
           fi
 
-      - name: Enable auto-merge
+      # The label is re-read live rather than taken from the event payload. A label
+      # applied while this run was in flight is not in that payload, and the disarm
+      # workflow runs in its own concurrency group, so it can finish before this step
+      # arms -- leaving the PR armed with the kill switch applied. Checking here closes
+      # that ordering gap; the disarm workflow covers the label arriving afterwards.
+      - name: Re-check the kill switch, then enable auto-merge
         if: steps.eligible.outputs.should_merge == 'true'
-        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          if gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name' \
+              | grep -qx 'do not auto-merge'; then
+            echo "::warning::do not auto-merge applied since this run started; not arming."
+            exit 0
+          fi
+          gh pr merge --auto --squash "$PR_URL"

--- a/.github/workflows/bot-automerge.yml
+++ b/.github/workflows/bot-automerge.yml
@@ -95,15 +95,18 @@ jobs:
           # code through a path that approves and merges itself. Require every commit to
           # be the bot's own. An unreadable or unmatched author counts as foreign, so the
           # probe fails closed.
-          # Emits a sentinel rather than an empty string for an unlinked author: command
-          # substitution strips trailing newlines, so a null author on the final commit
-          # would vanish before the loop counted it and the guard would pass.
-          if ! logins=$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}/commits" --paginate \
-              --jq '.[].author.login // "<none>"' 2>/dev/null); then
-            echo "::warning::Could not read commit authors for #${PR_NUMBER}; holding."
-            echo "should_merge=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+          # `set -e` does the fail-closed work. Every hand-written error branch here has
+          # been a way to fail open instead: a swallowed failure becomes "no findings" and
+          # the guard passes. So no `2>/dev/null` and no `|| fallback` -- if the query
+          # fails, the step dies, should_merge is never set, the steps below skip, and the
+          # error is in the log where whoever is debugging can read it.
+          #
+          # A sentinel, not an empty string, for an unlinked author: command substitution
+          # strips trailing newlines, so a null author on the final commit would vanish
+          # before the loop counted it and the guard would pass.
+          set -euo pipefail
+          logins=$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}/commits" --paginate \
+            --jq '.[].author.login // "<none>"')
           # Counted apart so the reason is accurate: an unlinked author is not the same
           # finding as a commit by somebody else, and reporting either as the other sends
           # whoever reads the log looking in the wrong place.
@@ -161,8 +164,12 @@ jobs:
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          if gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name' \
-              | grep -qx 'do not auto-merge'; then
+          # Read into a variable first, under `set -e`. Piping the query straight into
+          # grep would treat a failed query as "label absent" -- grep sees no input,
+          # matches nothing, and the step arms without ever having verified the switch.
+          set -euo pipefail
+          labels=$(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name')
+          if grep -qx 'do not auto-merge' <<< "$labels"; then
             echo "::warning::do not auto-merge applied since this run started; not arming."
             exit 0
           fi

--- a/.github/workflows/bot-automerge.yml
+++ b/.github/workflows/bot-automerge.yml
@@ -1,15 +1,40 @@
 ---
 name: Bot auto-merge
 
+# Arms GitHub's native auto-merge (squash) on Dependabot patch/minor PRs and on
+# pre-commit-ci hook bumps. GitHub performs the merge only once the PR is mergeable --
+# required checks green, no unresolved review threads -- so leaving a review comment
+# pauses it until that thread is resolved.
+#
+# Major bumps are left for a human on purpose. Consider what the required checks
+# actually cover: unit and E2E tests, pre-commit, and Package VSIX (which runs
+# `make verify-reproducible`). None of them execute publish.yml, which only triggers on
+# `release` and workflow_dispatch -- and that is precisely where a github-actions major
+# lands. A green PR is therefore not evidence that a major is safe, so auto-merging one
+# risks breaking publishing unattended.
+#
+# The guard reads pull_request.user.login, not github.actor. github.actor is whoever
+# triggered *this* event rather than whoever opened the PR, so any later push by another
+# identity makes that synchronize event's actor the other identity and the job skips --
+# leaving only the `opened` event as a chance to act, with no retry. user.login stays
+# dependabot[bot] for the life of the PR. It is not spoofable: GitHub records it as the
+# authenticated author, never derived from PR content, and the [bot] suffix cannot occur
+# in a human account name.
+#
+# There is deliberately no in-workflow check polling. `gh pr checks --watch` races check
+# registration and fails with "no required checks reported" before CI has posted;
+# native auto-merge gates on the ruleset server-side instead.
+#
+# The merge is attributed to github-actions[bot], which suppresses downstream push
+# events. Nothing here depends on those: changelog-autoupdate.yml runs on a schedule and
+# publish.yml triggers on releases.
+
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
 
-# A ruleset that requires status checks to pass should be configured for the repository.
-
 permissions:
   contents: write
-  packages: read
   pull-requests: write
 
 concurrency:
@@ -18,73 +43,73 @@ concurrency:
 
 jobs:
   bot-automerge:
-    runs-on: ubuntu-latest
+    # `do not auto-merge` is the kill switch, and this is the path that needs one:
+    # arming takes no human action, so without a label there is nothing to withhold.
+    # The workflow re-runs on labeled and unlabeled, so applying the label mid-flight
+    # re-evaluates and stops arming.
     if: >-
       github.event.pull_request.head.repo.full_name == github.repository &&
-      (github.actor == 'dependabot[bot]' || github.actor == 'pre-commit-ci[bot]')
-    timeout-minutes: 30
+      (github.event.pull_request.user.login == 'dependabot[bot]' ||
+      github.event.pull_request.user.login == 'pre-commit-ci[bot]') &&
+      !contains(github.event.pull_request.labels.*.name, 'do not auto-merge')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      PR_NUMBER: ${{ github.event.pull_request.number }}
+      GH_TOKEN: ${{ github.token }}
+      PR_URL: ${{ github.event.pull_request.html_url }}
     steps:
-      - uses: actions/checkout@v7
-      - name: Dependabot metadata
-        if: github.actor == 'dependabot[bot]'
-        id: dependabot
+      # No checkout step: nothing below reads the repository.
+      - name: Fetch Dependabot metadata
+        id: meta
+        if: github.event.pull_request.user.login == 'dependabot[bot]'
         uses: dependabot/fetch-metadata@v3
-        with:
-          github-token: ${{ env.GITHUB_TOKEN }}
-      - name: Check merge eligibility
+
+      # Dependabot's metadata trailer omits update-type for some ecosystems. v3 recovers
+      # it by parsing the "Updates X from A to B" line in the commit message; v2 did not.
+      # Keep this at v3 or newer or those ecosystems silently stop merging. When even
+      # that recovery finds no versions there is nothing to gate on, so hold for a human
+      # -- but say so, because a green run that merged nothing is otherwise
+      # indistinguishable from a deliberate hold.
+      - name: Report metadata that cannot be gated on
+        if: >-
+          github.event.pull_request.user.login == 'dependabot[bot]' &&
+          !steps.meta.outputs.update-type
+        env:
+          ECOSYSTEM: ${{ steps.meta.outputs.package-ecosystem }}
+        run: |
+          echo "::notice::No update-type for ${ECOSYSTEM:-unknown}; leaving this for a human."
+
+      - name: Decide eligibility
         id: eligible
         env:
-          ACTOR: ${{ github.actor }}
-          UPDATE_TYPE: ${{ steps.dependabot.outputs.update-type }}
-          HAS_DO_NOT_MERGE: ${{contains(github.event.pull_request.labels.*.name, 'do not auto-merge') }} # yamllint disable-line rule:line-length
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+          UPDATE_TYPE: ${{ steps.meta.outputs.update-type }}
         run: |
-          if [ "$HAS_DO_NOT_MERGE" = "true" ]; then
-            echo "::warning::PR has 'do not auto-merge' label, skipping"
-            echo "should_merge=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          if [ "$ACTOR" = "dependabot[bot]" ]; then
-            # Dependabot: only auto-merge patch/minor updates
-            if [ "$UPDATE_TYPE" = "version-update:semver-patch" ] || \
-               [ "$UPDATE_TYPE" = "version-update:semver-minor" ]; then
-              echo "::info::Dependabot patch/minor update, eligible for auto-merge"
-              echo "should_merge=true" >> "$GITHUB_OUTPUT"
-            else
-              echo "::warning::Dependabot major update, skipping auto-merge"
-              echo "should_merge=false" >> "$GITHUB_OUTPUT"
-            fi
-          elif [ "$ACTOR" = "pre-commit-ci[bot]" ]; then
-            # pre-commit-ci: auto-merge all PRs (they're always hook updates)
-            echo "::info::pre-commit-ci PR, eligible for auto-merge"
+          if [ "$AUTHOR" = "pre-commit-ci[bot]" ]; then
+            echo "::notice::pre-commit-ci hook bump; eligible for auto-merge."
             echo "should_merge=true" >> "$GITHUB_OUTPUT"
+          elif [ "$UPDATE_TYPE" = "version-update:semver-patch" ] || \
+               [ "$UPDATE_TYPE" = "version-update:semver-minor" ]; then
+            echo "::notice::Dependabot ${UPDATE_TYPE}; eligible for auto-merge."
+            echo "should_merge=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::Holding ${UPDATE_TYPE:-unknown update type} for a human."
+            echo "should_merge=false" >> "$GITHUB_OUTPUT"
           fi
-      - name: Wait for required checks
-        id: checks
+
+      # Kept even though the upstream copy of this workflow has no approval step: that
+      # repository requires no approving review, whereas the main-protect ruleset here
+      # requires one. Without this, auto-merge would arm and then wait indefinitely.
+      - name: Approve
         if: steps.eligible.outputs.should_merge == 'true'
         run: |
-          echo "::info::Waiting for required checks to pass..."
-          if gh pr checks "$PR_NUMBER" --required --watch --fail-fast; then
-            echo "::info::All required checks passed"
-            echo "checks_passed=true" >> "$GITHUB_OUTPUT"
+          decision=$(gh pr view "$PR_URL" --json reviewDecision -q .reviewDecision)
+          if [ "$decision" = "APPROVED" ]; then
+            echo "::notice::Already approved."
           else
-            echo "::error::Required checks failed"
-            exit 1
+            gh pr review --approve "$PR_URL"
           fi
-      - name: Approve PR
-        if: steps.checks.outputs.checks_passed == 'true'
-        run: |
-          REVIEW_STATE=$(gh pr view "$PR_NUMBER" --json reviewDecision -q .reviewDecision)
-          if [ "$REVIEW_STATE" != "APPROVED" ]; then
-            echo "::info::Approving PR..."
-            gh pr review --approve "$PR_NUMBER"
-          else
-            echo "::info::PR already approved."
-          fi
+
       - name: Enable auto-merge
         if: steps.eligible.outputs.should_merge == 'true'
-        run: |
-          echo "::info::Enabling auto-merge for PR #$PR_NUMBER"
-          gh pr merge --auto --squash "$PR_NUMBER"
+        run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
Rewrites `.github/workflows/bot-automerge.yml` and adds `.github/workflows/bot-automerge-disarm.yml`, so that Dependabot and pre-commit-ci pull requests can merge themselves safely.

> Body rewritten after merge. It originally described only the first of the four commits below, and omitted the disarm workflow and the commit-authorship check entirely. See #235 and #236 for later corrections to this work.

## What this workflow does

When Dependabot or pre-commit-ci opens a pull request, this arms GitHub's native auto-merge. GitHub then merges it once the branch is mergeable — required checks green, no unresolved review threads — so leaving a review comment pauses it until that thread is resolved. It also approves the PR, because the `main-protect` ruleset requires one approving review and auto-merge would otherwise arm and wait forever.

Because it approves and merges with no human involved, a bug that makes it *too permissive* is expensive, while one that makes it too strict is merely annoying. Every guard below is written to fail in the strict direction.

## Four problems fixed

**1. The eligibility check read the wrong identity.** It used `github.actor`, which is whoever triggered the current event, not whoever opened the pull request. Any later push by a different identity turns the `synchronize` event's actor into that identity and the job skips — leaving only the `opened` event as a chance to act, with no retry. It now reads `pull_request.user.login`, which stays `dependabot[bot]` for the life of the PR.

**2. The `do not auto-merge` label could not actually stop a merge.** The label only prevented the job from running again. Auto-merge, once enabled, lives on GitHub's side, so a label applied afterwards changed nothing and the merge still happened. `bot-automerge-disarm.yml` now turns it off, and the arming step re-reads the label immediately before arming to cover a label that arrives mid-run. The label did not exist in the repository at all, so the kill switch the old workflow referenced could never have been applied; it has been created.

**3. Anything pushed onto a bot's branch inherited the bot's eligibility.** Keying on the PR author means a commit pushed by somebody else still looks like a bot PR, so a collaborator could land arbitrary code through a path that approves and merges itself. Every commit is now checked. *(This check was later found to be weaker than intended and was replaced in #235 — see below.)*

**4. Waiting for checks in-workflow raced their registration.** `gh pr checks --required --watch` fails with "no required checks reported" when it runs before CI has posted. That step is gone; `gh pr merge --auto` already gates on the ruleset server-side, which is the point of `--auto`.

## Deliberate choices

**Majors are left for a human.** *(Superseded — see #235 and #236, which allow npm majors and actions majors that only touch workflows CI runs.)*

**pre-commit-ci is included**, unlike the upstream workflow this was adapted from, because it opens pull requests in this repository too.

**Approval is kept**, also unlike upstream, because that repository requires no approving review and this one requires one.

## Known limitation, fixed later

The commit check introduced here compares `.author.login` against the bot. That field is resolved from the commit's *author email*, so anyone who can push can set it to Dependabot's noreply address and be read as the bot. #235 replaces it with a check on GitHub's own commit signature, which cannot be forged.

## Verified

`yamllint`, `actionlint` and `shellcheck` pass. No `${{ }}` interpolation appears inside any `run:` block — every value is bound through `env:` first, so no PR-controlled text reaches a shell.
