### PR TITLE
ci: gate majors on ecosystem, not file paths

### DIFF
--- a/.github/workflows/bot-automerge.yml
+++ b/.github/workflows/bot-automerge.yml
@@ -51,22 +51,10 @@ jobs:
     # This check alone only stops the job from arming again. Auto-merge already enabled
     # lives server-side, so a label applied afterwards would not turn it off --
     # bot-automerge-disarm.yml does that, and is the half that makes arming defensible.
-    #
-    # Both identities are checked, because each covers what the other misses.
-    # pull_request.user.login says the PR is a bot's and stays true for its whole life, so
-    # a bot-pushed synchronize does not lose the only chance to act. github.actor says
-    # *this* event was not a human pushing onto that branch -- which user.login cannot
-    # tell, and which the commit-authorship probe below cannot reliably tell either, since
-    # .author.login is resolved from the commit's author email and anyone who can push can
-    # set that to dependabot's noreply address. Requiring both means a human push skips the
-    # job outright rather than relying on a probe that can be spoofed.
     if: >-
       github.event.pull_request.head.repo.full_name == github.repository &&
       (github.event.pull_request.user.login == 'dependabot[bot]' ||
       github.event.pull_request.user.login == 'pre-commit-ci[bot]') &&
-      (github.actor == 'dependabot[bot]' ||
-      github.actor == 'pre-commit-ci[bot]' ||
-      github.actor == 'github-actions[bot]') &&
       !contains(github.event.pull_request.labels.*.name, 'do not auto-merge')
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -104,43 +92,54 @@ jobs:
           ECOSYSTEM: ${{ steps.meta.outputs.package-ecosystem }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          # Keying on the PR author is what makes the guard survive later pushes by other
-          # identities, but on its own it would also let anything pushed onto a bot's
-          # branch inherit the bot's eligibility -- a collaborator could land arbitrary
-          # code through a path that approves and merges itself. Require every commit to
-          # be the bot's own. An unreadable or unmatched author counts as foreign, so the
-          # probe fails closed.
-          # `set -e` does the fail-closed work. Every hand-written error branch here has
-          # been a way to fail open instead: a swallowed failure becomes "no findings" and
-          # the guard passes. So no `2>/dev/null` and no `|| fallback` -- if the query
-          # fails, the step dies, should_merge is never set, the steps below skip, and the
-          # error is in the log where whoever is debugging can read it.
+          # Every commit must have been created by GitHub itself, and be the bot's own
+          # unless it is a merge.
           #
-          # A sentinel, not an empty string, for an unlinked author: command substitution
-          # strips trailing newlines, so a null author on the final commit would vanish
-          # before the loop counted it and the guard would pass.
+          # The signature is the load-bearing half. Author identity alone is not a guard:
+          # .author.login is resolved from the commit's author email, so anyone who can
+          # push can set it to dependabot's noreply address and be read as the bot. A
+          # commit created through GitHub -- by Dependabot, by pre-commit-ci, or by the
+          # Update branch button -- is signed by GitHub's key, and its signed payload names
+          # `committer GitHub <noreply@github.com>`. A collaborator cannot forge that
+          # without GitHub's private key, and the payload is inside the signature, so it
+          # cannot be edited either. A locally pushed commit is signed by the pusher's own
+          # key, or not at all.
+          #
+          # Merges are exempt from the author check but not from the signature check, and
+          # that pairing is what makes the exemption safe. A merge commit's tree is not
+          # constrained to be the mechanical merge of its parents, so a local "evil merge"
+          # can carry content present in neither parent while contributing no non-merge
+          # commits to the range. Requiring GitHub's signature rules that out: the only
+          # merges GitHub signs are the mechanical ones its own UI produces, and the button
+          # cannot inject a tree. That is what lets a required Update branch merge through
+          # without reopening the hole.
+          #
+          # `set -e` does the fail-closed work. Every hand-written error branch here has
+          # been a way to fail open instead. So no `2>/dev/null` and no `|| fallback` -- if
+          # the query fails the step dies, should_merge is never set, the steps below skip,
+          # and the error is in the log where whoever is debugging can read it.
           set -euo pipefail
-          logins=$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}/commits" --paginate \
-            --jq '.[].author.login // "<none>"')
-          # Counted apart so the reason is accurate: an unlinked author is not the same
-          # finding as a commit by somebody else, and reporting either as the other sends
-          # whoever reads the log looking in the wrong place.
-          foreign=0
-          unlinked=0
-          while IFS= read -r login; do
-            if [ -z "$login" ] || [ "$login" = "<none>" ]; then
-              unlinked=$((unlinked + 1))
-            elif [ "$login" != "$AUTHOR" ]; then
-              foreign=$((foreign + 1))
+          jq_rows='.[] | [
+            (if (.commit.verification.verified == true)
+                and ((.commit.verification.payload // "") | split("\n")
+                     | any(startswith("committer GitHub <noreply@github.com>")))
+             then "github" else "elsewhere" end),
+            (if (.parents | length) >= 2 then "merge" else "plain" end),
+            (.author.login // "<none>")
+          ] | join("|")'
+          rows=$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}/commits" --paginate --jq "$jq_rows")
+          rejected=0
+          while IFS='|' read -r origin kind commit_author; do
+            [ -z "$origin" ] && continue
+            if [ "$origin" != "github" ]; then
+              echo "::warning::a commit was not created by GitHub; holding."
+              rejected=$((rejected + 1))
+            elif [ "$kind" != "merge" ] && [ "$commit_author" != "$AUTHOR" ]; then
+              echo "::warning::non-merge commit authored by ${commit_author}; holding."
+              rejected=$((rejected + 1))
             fi
-          done <<< "$logins"
-          if [ "$unlinked" -ne 0 ]; then
-            echo "::warning::${unlinked} commit(s) with no linked GitHub author; holding."
-            echo "should_merge=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          if [ "$foreign" -ne 0 ]; then
-            echo "::warning::${foreign} commit(s) not authored by ${AUTHOR}; holding."
+          done <<< "$rows"
+          if [ "$rejected" -ne 0 ]; then
             echo "should_merge=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/.github/workflows/bot-automerge.yml
+++ b/.github/workflows/bot-automerge.yml
@@ -6,12 +6,14 @@ name: Bot auto-merge
 # required checks green, no unresolved review threads -- so leaving a review comment
 # pauses it until that thread is resolved.
 #
-# Major bumps are left for a human on purpose. Consider what the required checks
-# actually cover: unit and E2E tests, pre-commit, and Package VSIX (which runs
-# `make verify-reproducible`). None of them execute publish.yml, which only triggers on
-# `release` and workflow_dispatch -- and that is precisely where a github-actions major
-# lands. A green PR is therefore not evidence that a major is safe, so auto-merging one
-# risks breaking publishing unattended.
+# npm majors ride on green CI; github-actions majors do not. The split is about what a
+# green PR is evidence of. CI drives the extension end to end -- type-check, lint, unit,
+# integration and E2E across two operating systems and two VSCode versions, and Package
+# VSIX, which runs `make verify-reproducible` and so exercises vsce. It drives almost none
+# of the workflows: six of the ten actions here appear only in workflows no pull request
+# runs, and azure/login and actions/attest-build-provenance appear solely in publish.yml,
+# which triggers on `release` and workflow_dispatch alone. A break there surfaces at
+# release time, not review time.
 #
 # The guard reads pull_request.user.login, not github.actor. github.actor is whoever
 # triggered *this* event rather than whoever opened the PR, so any later push by another
@@ -49,10 +51,22 @@ jobs:
     # This check alone only stops the job from arming again. Auto-merge already enabled
     # lives server-side, so a label applied afterwards would not turn it off --
     # bot-automerge-disarm.yml does that, and is the half that makes arming defensible.
+    #
+    # Both identities are checked, because each covers what the other misses.
+    # pull_request.user.login says the PR is a bot's and stays true for its whole life, so
+    # a bot-pushed synchronize does not lose the only chance to act. github.actor says
+    # *this* event was not a human pushing onto that branch -- which user.login cannot
+    # tell, and which the commit-authorship probe below cannot reliably tell either, since
+    # .author.login is resolved from the commit's author email and anyone who can push can
+    # set that to dependabot's noreply address. Requiring both means a human push skips the
+    # job outright rather than relying on a probe that can be spoofed.
     if: >-
       github.event.pull_request.head.repo.full_name == github.repository &&
       (github.event.pull_request.user.login == 'dependabot[bot]' ||
       github.event.pull_request.user.login == 'pre-commit-ci[bot]') &&
+      (github.actor == 'dependabot[bot]' ||
+      github.actor == 'pre-commit-ci[bot]' ||
+      github.actor == 'github-actions[bot]') &&
       !contains(github.event.pull_request.labels.*.name, 'do not auto-merge')
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -87,6 +101,7 @@ jobs:
         env:
           AUTHOR: ${{ github.event.pull_request.user.login }}
           UPDATE_TYPE: ${{ steps.meta.outputs.update-type }}
+          ECOSYSTEM: ${{ steps.meta.outputs.package-ecosystem }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           # Keying on the PR author is what makes the guard survive later pushes by other
@@ -136,6 +151,28 @@ jobs:
                [ "$UPDATE_TYPE" = "version-update:semver-minor" ]; then
             echo "::notice::Dependabot ${UPDATE_TYPE}; eligible for auto-merge."
             echo "should_merge=true" >> "$GITHUB_OUTPUT"
+          elif [ "$UPDATE_TYPE" = "version-update:semver-major" ]; then
+            # Majors are gated on ecosystem, because that is what decides whether a green
+            # PR is evidence. For npm, CI genuinely exercises the result: type-check,
+            # lint, 100 unit tests, integration and E2E across two operating systems and
+            # two VSCode versions, and Package VSIX, which runs `make verify-reproducible`
+            # and so drives vsce itself. For github-actions it is not: six of the ten
+            # actions used here appear only in workflows no pull request runs, and two of
+            # those -- azure/login and actions/attest-build-provenance -- exist solely in
+            # publish.yml, where a break is invisible until a release.
+            #
+            # Deliberately not a file-path test. "Does the diff touch publish.yml" reads
+            # like the same rule but is not: ovsx appears only in publish.yml and the
+            # Makefile publish targets, so an ovsx major changes publishing while the diff
+            # touches package.json alone and would sail through. Ecosystem needs no such
+            # proxy, and cannot be evaded by a rename or a truncated file list.
+            if [ "$ECOSYSTEM" = "npm" ]; then
+              echo "::notice::npm major; CI exercises the extension end to end; eligible."
+              echo "should_merge=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "::warning::${ECOSYSTEM:-unknown} major is not exercised by CI; holding."
+              echo "should_merge=false" >> "$GITHUB_OUTPUT"
+            fi
           else
             echo "::warning::Holding ${UPDATE_TYPE:-unknown update type} for a human."
             echo "should_merge=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Two changes to `.github/workflows/bot-automerge.yml`: Dependabot npm majors can now auto-merge, and the check deciding whether a pull request really belongs to a bot is replaced with one that cannot be forged.

> Body rewritten after merge. It originally described an `github.actor` gate that a later commit in this same pull request removed. See #236 for a subsequent correction to the majors rule.

## Background

`bot-automerge.yml` approves and merges Dependabot and pre-commit-ci pull requests with no human involved (added in #233). Two of its rules were wrong.

## Major version bumps: npm now merges, github-actions does not

Previously all majors were held. That is too strict for npm and, as it turns out, not the right axis to split on.

The question is what a green CI run is evidence *of*. For npm, CI drives the actual product: type-check, lint, 100 unit tests, integration and E2E across two operating systems and two VSCode versions, and `Package VSIX`, which runs `make verify-reproducible` and so exercises `vsce` itself. A green npm PR is real evidence.

For `github-actions` it is not. Six of the ten actions used here appear only in workflows that no pull request executes, and two of those — `azure/login` and `actions/attest-build-provenance` — exist solely in `publish.yml`, which triggers on `release` and `workflow_dispatch`. A break there is invisible until a release.

**Why not "hold if the diff touches `publish.yml`"?** That sounds equivalent and is not. `ovsx` appears only in `publish.yml` and the Makefile publish targets, so an `ovsx` major changes publishing while the diff touches `package.json` alone — it would sail through. Ecosystem needs no such proxy. (#236 later shows a per-file test *is* sound for the github-actions ecosystem specifically, because an action runs only where its `uses:` line is written.)

Roughly 36 of the last 41 Dependabot pull requests here are npm, so this covers most of the traffic.

## Commit provenance: GitHub's signature, not the author field

The previous check compared each commit's `.author.login` against the bot. **That was never a real guard.** GitHub resolves `.author.login` from the commit's *author email*, so anyone who can push to the branch can set it to `49699333+dependabot[bot]@users.noreply.github.com` and be read as Dependabot.

Every commit must now have been created by GitHub itself: `verification.verified == true` **and** a signed payload naming `committer GitHub <noreply@github.com>`. A commit made through GitHub — by Dependabot, by pre-commit-ci, or by the *Update branch* button — carries that. A commit pushed from a clone is signed by the pusher's own key, or not at all.

Both halves are load-bearing. The payload line alone would be forgeable by setting the committer locally; `verified` alone would accept any signed commit. Tested by attempting exactly that forgery — author set to Dependabot, committer set to `GitHub <noreply@github.com>`, signed with a personal key. Git accepted it locally (`%G?` = `G`); GitHub reported:

```
verified: false
reason:   unknown_key
```

Merge commits are exempt from the author check but **not** from the signature check, and that pairing is what makes the exemption safe. A merge commit's tree is not constrained to be the mechanical merge of its parents, so a merge crafted locally can carry content present in neither parent while contributing no ordinary commits to the range. Requiring GitHub's signature rules that out: the only merges GitHub signs are the mechanical ones its own button produces, and a button cannot inject a tree. That is what lets a required *Update branch* merge through without opening a hole.

## Behaviour

| case | result |
| --- | --- |
| Dependabot or pre-commit-ci commit | merge |
| bot commit plus a GitHub *Update branch* merge | merge |
| merge crafted locally carrying extra content | hold |
| local push with a spoofed bot author email | hold |
| file edited in the GitHub web UI by a human | hold — signed by GitHub, but neither a merge nor the bot's |
| commit whose author is not a linked GitHub account | hold |
| npm major | merge |
| github-actions major | hold |
| major with no ecosystem reported, or no update type | hold |

## Verified

`yamllint`, `actionlint` and `shellcheck` pass. The classification query was extracted from the workflow file itself and run against real pull requests in this repository: Dependabot and pre-commit-ci PRs classify as GitHub-created, a human-authored PR does not.
