### PR TITLE
ci: unhold actions majors CI actually runs

### DIFF
--- a/.github/workflows/bot-automerge-disarm.yml
+++ b/.github/workflows/bot-automerge-disarm.yml
@@ -74,6 +74,14 @@ jobs:
             echo "::warning::attempt ${attempt}: auto-merge not yet confirmed off on #${PR_NUMBER}."
             sleep 5
           done
+          # One last read: the loop disables on its final pass and then falls straight
+          # through, so without this a disarm that worked on attempt three still reports
+          # failure and pages somebody to do what has already been done.
+          if [ "$(gh pr view "$PR_NUMBER" --json autoMergeRequest \
+              --jq '.autoMergeRequest != null')" = "false" ]; then
+            echo "::notice::Auto-merge is off on PR #${PR_NUMBER}."
+            exit 0
+          fi
           echo "::error::Could not confirm auto-merge is off on #${PR_NUMBER}. Disable it by hand:"
           echo "::error::gh pr merge --disable-auto ${PR_NUMBER} --repo ${GH_REPO}"
           exit 1

--- a/.github/workflows/bot-automerge.yml
+++ b/.github/workflows/bot-automerge.yml
@@ -130,7 +130,7 @@ jobs:
           # This endpoint returns at most 250 commits and --paginate still exits 0, so a
           # longer PR would be inspected only in part and the unseen tail could be
           # anything. Count first and refuse rather than under-inspect. A bot PR reaching
-          # 250 commits means something is wrong regardless.
+          # 250 commits suggests something is wrong regardless.
           total=$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}" --jq '.commits')
           if [ "$total" -gt 250 ]; then
             echo "::warning::${total} commits exceeds the 250 this API returns; holding."

--- a/.github/workflows/bot-automerge.yml
+++ b/.github/workflows/bot-automerge.yml
@@ -195,8 +195,14 @@ jobs:
               # Note the repository floats major tags (@v7, not @v7.0.1), so Dependabot
               # raises an actions PR only when a major moves -- which made a blanket
               # semver-major hold a blanket hold on every actions PR there will ever be.
-              held=$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}/files" --paginate \
-                --jq '.[] | .filename, (.previous_filename // empty)' \
+              # Query and match are separate statements on purpose. As one pipeline the
+              # trailing `|| true` -- needed because grep exits 1 when it matches nothing
+              # -- also swallows the query failing, and an unreadable file list would then
+              # count as zero held files and arm. Split, the query is bare so `set -e`
+              # kills the step if it fails, and `|| true` covers only the honest no-match.
+              changed=$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}/files" --paginate \
+                --jq '.[] | .filename, (.previous_filename // empty)')
+              held=$(printf '%s\n' "$changed" \
                 | grep -cFx -e '.github/workflows/publish.yml' \
                              -e '.github/workflows/changelog-autoupdate.yml' \
                              -e '.github/workflows/pre-commit-autoupdate.yml' || true)

--- a/.github/workflows/bot-automerge.yml
+++ b/.github/workflows/bot-automerge.yml
@@ -127,7 +127,23 @@ jobs:
             (if (.parents | length) >= 2 then "merge" else "plain" end),
             (.author.login // "<none>")
           ] | join("|")'
+          # This endpoint returns at most 250 commits and --paginate still exits 0, so a
+          # longer PR would be inspected only in part and the unseen tail could be
+          # anything. Count first and refuse rather than under-inspect. A bot PR reaching
+          # 250 commits means something is wrong regardless.
+          total=$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}" --jq '.commits')
+          if [ "$total" -gt 250 ]; then
+            echo "::warning::${total} commits exceeds the 250 this API returns; holding."
+            echo "should_merge=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           rows=$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}/commits" --paginate --jq "$jq_rows")
+          seen=$(printf '%s\n' "$rows" | grep -c . || true)
+          if [ "$seen" -ne "$total" ]; then
+            echo "::warning::inspected ${seen} of ${total} commits; holding."
+            echo "should_merge=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           rejected=0
           while IFS='|' read -r origin kind commit_author; do
             [ -z "$origin" ] && continue
@@ -168,6 +184,29 @@ jobs:
             if [ "$ECOSYSTEM" = "npm" ]; then
               echo "::notice::npm major; CI exercises the extension end to end; eligible."
               echo "should_merge=true" >> "$GITHUB_OUTPUT"
+            elif [ "$ECOSYSTEM" = "github-actions" ]; then
+              # For actions the changed file IS the blast radius: an action runs only
+              # where its `uses:` line is written. So a per-file test is sound here, where
+              # for npm it was not -- ovsx is used by publish.yml while the diff touches
+              # package.json alone. Held only when the diff reaches a workflow no pull
+              # request executes; those are listed rather than inferred, because a
+              # workflow's triggers can change without this file noticing.
+              #
+              # Note the repository floats major tags (@v7, not @v7.0.1), so Dependabot
+              # raises an actions PR only when a major moves -- which made a blanket
+              # semver-major hold a blanket hold on every actions PR there will ever be.
+              held=$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}/files" --paginate \
+                --jq '.[] | .filename, (.previous_filename // empty)' \
+                | grep -cFx -e '.github/workflows/publish.yml' \
+                             -e '.github/workflows/changelog-autoupdate.yml' \
+                             -e '.github/workflows/pre-commit-autoupdate.yml' || true)
+              if [ "$held" -ne 0 ]; then
+                echo "::warning::actions major touches a workflow no PR runs; holding."
+                echo "should_merge=false" >> "$GITHUB_OUTPUT"
+              else
+                echo "::notice::actions major, only in workflows CI runs; eligible."
+                echo "should_merge=true" >> "$GITHUB_OUTPUT"
+              fi
             else
               echo "::warning::${ECOSYSTEM:-unknown} major is not exercised by CI; holding."
               echo "should_merge=false" >> "$GITHUB_OUTPUT"
@@ -177,25 +216,12 @@ jobs:
             echo "should_merge=false" >> "$GITHUB_OUTPUT"
           fi
 
-      # Kept even though the upstream copy of this workflow has no approval step: that
-      # repository requires no approving review, whereas the main-protect ruleset here
-      # requires one. Without this, auto-merge would arm and then wait indefinitely.
-      - name: Approve
-        if: steps.eligible.outputs.should_merge == 'true'
-        run: |
-          decision=$(gh pr view "$PR_URL" --json reviewDecision -q .reviewDecision)
-          if [ "$decision" = "APPROVED" ]; then
-            echo "::notice::Already approved."
-          else
-            gh pr review --approve "$PR_URL"
-          fi
-
       # The label is re-read live rather than taken from the event payload. A label
       # applied while this run was in flight is not in that payload, and the disarm
       # workflow runs in its own concurrency group, so it can finish before this step
       # arms -- leaving the PR armed with the kill switch applied. Checking here closes
       # that ordering gap; the disarm workflow covers the label arriving afterwards.
-      - name: Re-check the kill switch, then enable auto-merge
+      - name: Re-check the kill switch, then approve and arm
         if: steps.eligible.outputs.should_merge == 'true'
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -205,8 +231,25 @@ jobs:
           # matches nothing, and the step arms without ever having verified the switch.
           set -euo pipefail
           labels=$(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name')
-          if grep -qx 'do not auto-merge' <<< "$labels"; then
+          # Case-insensitive and fixed-string: GitHub treats label names as unique
+          # case-insensitively, so "Do Not Auto-Merge" is the same switch to a human and
+          # must be to this check too.
+          if grep -qixF 'do not auto-merge' <<< "$labels"; then
             echo "::warning::do not auto-merge applied since this run started; not arming."
             exit 0
+          fi
+          # Approving here rather than in a step of its own, so the approval and the
+          # arming stand or fall together. Approving first left a standing approval on a
+          # PR this step then declined to arm, and nothing withdraws it: the disarm
+          # workflow turns auto-merge off but does not dismiss a review.
+          #
+          # The approval exists at all because main-protect requires one review, unlike
+          # the upstream copy of this workflow, where auto-merge would otherwise arm and
+          # then wait forever.
+          decision=$(gh pr view "$PR_URL" --json reviewDecision -q .reviewDecision)
+          if [ "$decision" = "APPROVED" ]; then
+            echo "::notice::Already approved."
+          else
+            gh pr review --approve "$PR_URL"
           fi
           gh pr merge --auto --squash "$PR_URL"

--- a/.github/workflows/changelog-autoupdate.yml
+++ b/.github/workflows/changelog-autoupdate.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           fetch-depth: 0 # Full history needed for git cliff
       - name: Install git-cliff
-        uses: taiki-e/install-action@v2.85.3
+        uses: taiki-e/install-action@v2
         with:
           tool: git-cliff
       # git-cliff needs a token to resolve commit authors to GitHub usernames.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,6 +129,27 @@ git push origin <branch name>
 
 Then open a PR.
 
+#### Keeping the description true
+
+Revise the PR description whenever review changes what the branch does. A description
+written when the PR opened describes the branch as it was then, and on anything that takes
+more than one round it usually stops matching: an approach gets replaced, a fix turns out
+to be wrong, a reviewer's point reshapes the change. Reviewers read the description to
+decide what to look at, and after the merge it is the only prose explaining why the commit
+exists — the branch is gone and the discussion is buried.
+
+Two habits keep it honest:
+
+- When a later commit supersedes an earlier one, say so, rather than leaving both stories
+  standing. A description claiming a fix the branch no longer contains is worse than one
+  that says nothing.
+- Write for somebody who was not in the review. Avoid tool names, round numbers, and
+  references to who suggested what; describe the problem in terms of this repository, and
+  say how the change was checked.
+
+Editing a merged PR's description is fine and worth doing when it turns out to be wrong.
+Note at the top that it was rewritten, so the discussion below still makes sense.
+
 ## Creating a release
 
 1. Prepare a release branch: `git switch main && git pull && git switch -c release/vX.Y.Z`


### PR DESCRIPTION
Five corrections to the bot auto-merge workflows. The main one: Dependabot pull requests that bump GitHub Actions were being held unconditionally, which was never the intent.

## Actions majors were held for every actions PR there will ever be

Every action in this repository is pinned to a floating major — `@v7`, not `@v7.0.1`. GitHub Actions authors move the `v7` tag to each new v7.x.x release, so patch and minor upgrades arrive automatically and **Dependabot only opens a pull request when a major moves**.

The rule added in #235 held all `github-actions` majors. Combined with floating tags, that held *every* actions pull request, permanently. The reasoning behind it was sound but the axis was wrong.

For actions, the changed file is the blast radius: an action runs only where its `uses:` line is written. So a per-file test is sound here, even though it is not for npm — there `ovsx` is used by `publish.yml` while the diff touches `package.json` alone, which is why #235 uses ecosystem instead.

Actions majors now hold only when the diff reaches one of the three workflows that no pull request executes:

- `.github/workflows/publish.yml` — triggers on `release` and `workflow_dispatch`
- `.github/workflows/changelog-autoupdate.yml` — scheduled
- `.github/workflows/pre-commit-autoupdate.yml` — runs on push to main

These are listed explicitly rather than derived from each workflow's triggers, because a trigger can change without anyone updating this rule. `.previous_filename` is checked alongside `.filename`, so renaming a held workflow inside the same PR does not slip past.

Checked against real pull requests here: one that bumped four workflows including `publish.yml` holds; one touching only `ci.yml` merges.

**`taiki-e/install-action` returns to a floating major.** It was the only exact pin in the repository, which would have made it the only action producing patch-level pull requests.

## Four smaller fixes

| Problem | Consequence | Fix |
| --- | --- | --- |
| `GET /pulls/{n}/commits` returns at most 250 commits, and `--paginate` still exits 0 | A longer pull request was only partly inspected, and the unexamined commits could be anything | The commit count is read first and compared against the rows actually seen; either check failing holds the PR |
| The `do not auto-merge` label was matched case-sensitively | `Do Not Auto-Merge` is the same switch to a person and was a different one to the workflow | Matched case-insensitively, still as a fixed string |
| Approval ran before the final kill-switch check | A pull request could be left carrying an approval that the workflow then declined to merge, and nothing withdraws it — the disarm workflow turns auto-merge off but does not dismiss a review | Approval moved after that check, into the same step, so both stand or fall together |
| The disarm loop disabled auto-merge on its last attempt and then fell through without re-reading the state | A disarm that succeeded on the third try still reported failure and asked a human to repeat it | Verifies once more before reporting an error |

## Verified

`yamllint`, `actionlint` and `shellcheck` pass. The label match was exercised across upper, lower and mixed case; the per-file rule was simulated against two real pull requests; the truncation guard was run against live commit counts.
