### PR TITLE
docs: remove manual line breaks from prose

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -25,3 +25,4 @@ dd491d212aa5d82b907e4ac362f57d04c79c2f66  # style: add whitespace
 47e66a774a26fddf7edbe9c42aa445cf31aaf57a  # style(.github/dependabot.yml): use fewer quotes
 45d5b74c644893ff3bcf7dcb49dd49c9d2474f6b  # style: reorder imports
 f3a23771c9a662389237f0f4e41cd7d8f699299e  # style: restyle quotes and trailing commas
+029ff84fe93e127f02e037a4498b24707a0009f7  # docs: remove manual line breaks from prose

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,24 +131,14 @@ Then open a PR.
 
 #### Keeping the description true
 
-Revise the PR description whenever review changes what the branch does. A description
-written when the PR opened describes the branch as it was then, and on anything that takes
-more than one round it usually stops matching: an approach gets replaced, a fix turns out
-to be wrong, a reviewer's point reshapes the change. Reviewers read the description to
-decide what to look at, and after the merge it is the only prose explaining why the commit
-exists — the branch is gone and the discussion is buried.
+Revise the PR description whenever review changes what the branch does. A description written when the PR opened describes the branch as it was then, and on anything that takes more than one round it usually stops matching: an approach gets replaced, a fix turns out to be wrong, a reviewer's point reshapes the change. Reviewers read the description to decide what to look at, and after the merge it is the only prose explaining why the commit exists — the branch is gone and the discussion is buried.
 
 Two habits keep it honest:
 
-- When a later commit supersedes an earlier one, say so, rather than leaving both stories
-  standing. A description claiming a fix the branch no longer contains is worse than one
-  that says nothing.
-- Write for somebody who was not in the review. Avoid tool names, round numbers, and
-  references to who suggested what; describe the problem in terms of this repository, and
-  say how the change was checked.
+- When a later commit supersedes an earlier one, say so, rather than leaving both stories standing. A description claiming a fix the branch no longer contains is worse than one that says nothing.
+- Write for somebody who was not in the review. Avoid tool names, round numbers, and references to who suggested what; describe the problem in terms of this repository, and say how the change was checked.
 
-Editing a merged PR's description is fine and worth doing when it turns out to be wrong.
-Note at the top that it was rewritten, so the discussion below still makes sense.
+Editing a merged PR's description is fine and worth doing when it turns out to be wrong. Note at the top that it was rewritten, so the discussion below still makes sense.
 
 ## Creating a release
 
@@ -170,67 +160,37 @@ Note at the top that it was rewritten, so the discussion below still makes sense
 11. Push with tags: `git push --follow-tags`
 12. Create a GitHub release from the tag: `make release VERSION=vX.Y.Z`
 13. Review the release notes and edit them if needed (via GitHub web UI).
-14. The `publish extension` workflow fires on `release: published` and does the rest:
-    it builds one VSIX, attests it, attaches it to the release, and publishes that same
-    file to the VSCode Marketplace and Open VSX.
+14. The `publish extension` workflow fires on `release: published` and does the rest: it builds one VSIX, attests it, attaches it to the release, and publishes that same file to the VSCode Marketplace and Open VSX.
 
 ### Publishing
 
-Releases publish themselves. `.github/workflows/publish.yml` verifies the tag matches
-`package.json`, builds the VSIX once via `make package-vsix` (so marketplace README
-preparation happens exactly one way), then publishes to both registries.
+Releases publish themselves. `.github/workflows/publish.yml` verifies the tag matches `package.json`, builds the VSIX once via `make package-vsix` (so marketplace README preparation happens exactly one way), then publishes to both registries.
 
 Repository secrets required:
 
-- `VSCE_PAT`: Azure DevOps personal access token for the VSCode Marketplace.
-  Create it with **Organization: All accessible organizations** and scope
-  **Marketplace → Manage**. Any narrower organization or scope fails with a 401.
+- `VSCE_PAT`: Azure DevOps personal access token for the VSCode Marketplace. Create it with **Organization: All accessible organizations** and scope **Marketplace → Manage**. Any narrower organization or scope fails with a 401.
 - `OVSX_PAT`: Open VSX access token for the `michen00` namespace
 
 #### Marketplace auth migration (before 2026-12-01)
 
-Azure DevOps retires global PATs on **2026-12-01**, and a global PAT — one scoped to all
-accessible organizations — is currently the only kind that can reach the Marketplace. After
-that date `VSCE_PAT` stops working.
+Azure DevOps retires global PATs on **2026-12-01**, and a global PAT — one scoped to all accessible organizations — is currently the only kind that can reach the Marketplace. After that date `VSCE_PAT` stops working.
 
-The workflow already supports the replacement. Set two repository **variables** and it
-switches to Entra ID federated auth via `vsce publish --azure-credential`, storing no
-long-lived secret:
+The workflow already supports the replacement. Set two repository **variables** and it switches to Entra ID federated auth via `vsce publish --azure-credential`, storing no long-lived secret:
 
 - `AZURE_CLIENT_ID`: the Entra app registration's client ID
 - `AZURE_TENANT_ID`: the Entra tenant ID
 
-Setup requires an Entra app registration, a GitHub federated credential scoped to this
-repository, and that identity added as a member of the `michen00` Marketplace publisher.
-Once a publish succeeds that way, delete the `VSCE_PAT` secret. Open VSX is unaffected.
+Setup requires an Entra app registration, a GitHub federated credential scoped to this repository, and that identity added as a member of the `michen00` Marketplace publisher. Once a publish succeeds that way, delete the `VSCE_PAT` secret. Open VSX is unaffected.
 
-To publish a tag manually — backfilling a release, or retrying after one registry fails —
-run the workflow via `workflow_dispatch` with a `tag` and a `targets` choice of `both`,
-`vscode`, or `openvsx`. Target a single registry when retrying, since republishing an
-already-published version fails.
+To publish a tag manually — backfilling a release, or retrying after one registry fails — run the workflow via `workflow_dispatch` with a `tag` and a `targets` choice of `both`, `vscode`, or `openvsx`. Target a single registry when retrying, since republishing an already-published version fails.
 
-Manual dispatch only works for **v0.4.0 and later**. `workflow_dispatch` takes the workflow
-definition from the ref you dispatch on but checks out the tag you name, and the build step
-calls `make verify-reproducible`. Tags from v0.3.1 back have neither that target nor
-`scripts/normalize-vsix.mjs`, so the job fails at the build step.
+Manual dispatch only works for **v0.4.0 and later**. `workflow_dispatch` takes the workflow definition from the ref you dispatch on but checks out the tag you name, and the build step calls `make verify-reproducible`. Tags from v0.3.1 back have neither that target nor `scripts/normalize-vsix.mjs`, so the job fails at the build step.
 
-**Do not try to backfill an older version by hand.** `vsce` and `ovsx` take the version from
-the checked-out `package.json`, so a tree that mixes this tooling with an old tag publishes
-whichever version that tree happens to declare — not necessarily the one you meant. Both
-registries refuse to republish a version that already exists, so a wrong number cannot be
-corrected, only abandoned. If a registry is missing a version, release forward.
+**Do not try to backfill an older version by hand.** `vsce` and `ovsx` take the version from the checked-out `package.json`, so a tree that mixes this tooling with an old tag publishes whichever version that tree happens to declare — not necessarily the one you meant. Both registries refuse to republish a version that already exists, so a wrong number cannot be corrected, only abandoned. If a registry is missing a version, release forward.
 
-Retrying one registry is safe because the package is byte-reproducible. `make
-package-vsix` pins entry timestamps and Unix modes via `scripts/normalize-vsix.mjs`, and
-pins `SOURCE_DATE_EPOCH` so vsce also sorts entries, so rebuilding a tag yields identical
-bytes and both registries end up with the same artifact. Confirm with `make
-verify-reproducible`, which builds twice — under two different umasks — and compares.
+Retrying one registry is safe because the package is byte-reproducible. `make package-vsix` pins entry timestamps and Unix modes via `scripts/normalize-vsix.mjs`, and pins `SOURCE_DATE_EPOCH` so vsce also sorts entries, so rebuilding a tag yields identical bytes and both registries end up with the same artifact. Confirm with `make verify-reproducible`, which builds twice — under two different umasks — and compares.
 
-Reproducibility is the only thing preventing that divergence. The attest step has no
-condition on it, so a retry mints a fresh attestation over whatever it just built; those
-bytes always pass `gh attestation verify`. Provenance cannot tell you that two registries
-disagree. Before the pinning, a retry left them holding different bytes, the release asset
-clobbered with the later build, and one tag carrying two independently valid attestations.
+Reproducibility is the only thing preventing that divergence. The attest step has no condition on it, so a retry mints a fresh attestation over whatever it just built; those bytes always pass `gh attestation verify`. Provenance cannot tell you that two registries disagree. Before the pinning, a retry left them holding different bytes, the release asset clobbered with the later build, and one tag carrying two independently valid attestations.
 
 Local fallback (requires `VSCE_PAT` / `OVSX_PAT` in your environment):
 
@@ -244,18 +204,14 @@ make publish-all    # one build, both registries
 
 Two independent things are verifiable, and they cover different artifacts.
 
-**The source** — the signed tag. A signed annotated tag commits to the exact source tree
-through git's hash chain, so it needs no separate signed archive. The trusted public key
-is committed to `.github/allowed_signers`, so this works offline from a clone:
+**The source** — the signed tag. A signed annotated tag commits to the exact source tree through git's hash chain, so it needs no separate signed archive. The trusted public key is committed to `.github/allowed_signers`, so this works offline from a clone:
 
 ```bash
 git config gpg.ssh.allowedSignersFile .github/allowed_signers
 make verify-tag VERSION=vX.Y.Z          # or: git verify-tag vX.Y.Z
 ```
 
-**The artifact** — keyless build provenance. The publish workflow builds the VSIX once,
-attests that exact file with `actions/attest-build-provenance` (GitHub OIDC + sigstore, no
-signing secret), then publishes and attaches that same file:
+**The artifact** — keyless build provenance. The publish workflow builds the VSIX once, attests that exact file with `actions/attest-build-provenance` (GitHub OIDC + sigstore, no signing secret), then publishes and attaches that same file:
 
 ```bash
 gh release download vX.Y.Z --pattern '*.vsix'
@@ -263,13 +219,9 @@ gh attestation verify invisible-squiggles-<version>.vsix \
   --repo michen00/invisible-squiggles
 ```
 
-Note the two are not substitutes. The VSIX ships only a minified `dist/` bundle and no
-source files, so provenance proves "this bundle was built by this repo's CI at this
-commit" while the signed tag proves "this is the source the maintainer released." One
-build is attested, published, and attached, so the attested bytes are the shipped bytes.
+Note the two are not substitutes. The VSIX ships only a minified `dist/` bundle and no source files, so provenance proves "this bundle was built by this repo's CI at this commit" while the signed tag proves "this is the source the maintainer released." One build is attested, published, and attached, so the attested bytes are the shipped bytes.
 
-**Both together** — the package is byte-reproducible, so the two anchors can be joined.
-From a clone at a verified tag, rebuild and compare against the published artifact:
+**Both together** — the package is byte-reproducible, so the two anchors can be joined. From a clone at a verified tag, rebuild and compare against the published artifact:
 
 ```bash
 npm ci          # exact lockfile install, matching what CI does
@@ -278,28 +230,11 @@ shasum -a 256 invisible-squiggles-<version>.vsix
 # compare against the release asset downloaded above
 ```
 
-That closes the gap the minified bundle would otherwise leave: the signed tag vouches for
-the source, and an independent rebuild shows that source really does produce the shipped
-bytes. Two things are pinned to make this hold across machines — entry timestamps
-(1980-01-01) and entry Unix modes — because vsce otherwise copies each file's mode from
-disk, which makes the digest depend on the rebuilder's umask. See
-`scripts/normalize-vsix.mjs`.
+That closes the gap the minified bundle would otherwise leave: the signed tag vouches for the source, and an independent rebuild shows that source really does produce the shipped bytes. Two things are pinned to make this hold across machines — entry timestamps (1980-01-01) and entry Unix modes — because vsce otherwise copies each file's mode from disk, which makes the digest depend on the rebuilder's umask. See `scripts/normalize-vsix.mjs`.
 
-Use `npm ci`, not `npm install`. The bundle is whatever the pinned `esbuild` emits and the
-zip layout is whatever the pinned `vsce` writes, so a dependency tree that has drifted from
-`package-lock.json` can legitimately produce a different digest. `make verify-reproducible`
-checks the weaker, always-true property — that two builds of one tree agree — and is what
-guards the publish retry path.
+Use `npm ci`, not `npm install`. The bundle is whatever the pinned `esbuild` emits and the zip layout is whatever the pinned `vsce` writes, so a dependency tree that has drifted from `package-lock.json` can legitimately produce a different digest. `make verify-reproducible` checks the weaker, always-true property — that two builds of one tree agree — and is what guards the publish retry path.
 
-Reproducibility is guaranteed _for a given toolchain_, not universally. `package-lock.json`
-pins `vsce` and `esbuild`, and the publish workflow pins Node exactly
-(`node-version: 22.23.2`) rather than floating on `22.x`, because the deflate streams come
-from Node's bundled zlib — which `scripts/normalize-vsix.mjs` never touches, since it does
-not re-compress. Without that pin a patch bump between the original publish and a
-`targets:`-scoped retry could change the artifact. Bumping the pin is a deliberate act: it
-invalidates digest comparison against releases published on the previous version. To
-reproduce a release locally, match the Node version it was built with, and treat a mismatch
-as a toolchain difference to investigate before reading it as tampering.
+Reproducibility is guaranteed _for a given toolchain_, not universally. `package-lock.json` pins `vsce` and `esbuild`, and the publish workflow pins Node exactly (`node-version: 22.23.2`) rather than floating on `22.x`, because the deflate streams come from Node's bundled zlib — which `scripts/normalize-vsix.mjs` never touches, since it does not re-compress. Without that pin a patch bump between the original publish and a `targets:`-scoped retry could change the artifact. Bumping the pin is a deliberate act: it invalidates digest comparison against releases published on the previous version. To reproduce a release locally, match the Node version it was built with, and treat a mismatch as a toolchain difference to investigate before reading it as tampering.
 
 [issues]: https://github.com/michen00/invisible-squiggles/issues
 [issues_new]: https://github.com/michen00/invisible-squiggles/issues/new

--- a/scripts/fixtures/test-readme-expected.md
+++ b/scripts/fixtures/test-readme-expected.md
@@ -1,4 +1,3 @@
 # Test Workspace
 
-This folder is used by the VS Code test runner (`@vscode/test-cli`) as the workspace opened during
-integration and E2E tests.
+This folder is used by the VS Code test runner (`@vscode/test-cli`) as the workspace opened during integration and E2E tests.

--- a/test-workspace/README.md
+++ b/test-workspace/README.md
@@ -1,7 +1,6 @@
 # Test Workspace
 
-This folder is used by the VS Code test runner (`@vscode/test-cli`) as the workspace opened during
-integration and E2E tests.
+This folder is used by the VS Code test runner (`@vscode/test-cli`) as the workspace opened during integration and E2E tests.
 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.12345.svg)](https://doi.org/10.5281/zenodo.12345)
 


### PR DESCRIPTION
Style only — no content changes. Hard-wrapped paragraphs are joined into single lines, so future edits produce word-level diffs instead of reflowing whole paragraphs.

## Scope

Of the repository's twelve Markdown files, three are unwrapped here. The rest already had unwrapped prose, including `CHANGELOG.md`, which `git-cliff` generates.

| file | manual breaks removed |
| --- | --- |
| `CONTRIBUTING.md` | 65 |
| `test-workspace/README.md` | 1 |
| `scripts/fixtures/test-readme-expected.md` | 1 |

Unwrapped with the conservative tool from the `ai4inputs-splice-recon` repository, which classifies each region and leaves code fences, tables, lists, blockquotes, front matter and HTML comments alone.

## README.md is deliberately excluded

The tool gets it wrong. It treats a run of consecutive link-only lines as one wrapped paragraph, so it collapsed the nine badge lines at the top of `README.md` into a single 1274-character line.

That renders identically — Markdown joins adjacent lines within a paragraph anyway — which is exactly why a whitespace-insensitive comparison does not catch it. But each badge belongs on its own line so that adding or removing one shows up as a one-line diff, which is the whole point of unwrapping in the first place. A badge block is structure, not prose.

`README.md` is therefore untouched, and the bug is being fixed upstream in the tool's own repository.

## Why the test fixtures are included

`test-workspace/README.md` is the input to `scripts/test-prepare-readme.sh` and `scripts/fixtures/test-readme-expected.md` is its expected output. `prepare-readme.sh` strips whole lines, so unwrapping one without the other would merge a stripped line into surrounding prose and break the comparison. They are unwrapped together, and the test passes.

## Verification

Each file is byte-identical to its previous contents once whitespace is collapsed:

```
CONTRIBUTING.md                            identical ignoring whitespace
scripts/fixtures/test-readme-expected.md   identical ignoring whitespace
test-workspace/README.md                   identical ignoring whitespace
```

No resulting line exceeds 800 characters — the check that would have caught the `README.md` problem had it been applied the first time. `markdownlint` and `prettier` pass, and the full test suite passes.

Neither formatter will undo this: `markdownlint` sets `line-length: false`, and `prettier` leaves `proseWrap` at its default of `preserve`, so `printWidth` does not apply to prose.

The style-only commit is recorded in `.git-blame-ignore-revs` so `git blame` skips it.
