### PR TITLE
build(deps-dev): clear seven dev-tree advisories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,15 @@ jobs:
         run: npm run pretest
       - name: Run unit tests with coverage
         run: npm run test:coverage
+      # The same tests again, in mocha's parallel mode. Not for the tests --
+      # they already passed on the line above -- but for the one dependency the
+      # serial run never loads. mocha requires serialize-javascript only from
+      # lib/nodejs/buffered-worker-pool.js, so a serial run leaves it untouched,
+      # and package.json overrides it past the range mocha declares. Without
+      # this step nothing installs, loads, or executes the overridden package,
+      # and a breaking major would reach main with every check green.
+      - name: Run unit tests in parallel mode
+        run: npm run test:unit:parallel
       - name: Upload coverage to Codecov
         if: matrix.node == '22.x'
         uses: codecov/codecov-action@v7

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,7 +116,18 @@ npm audit fix --package-lock-only
 
 The rest are transitive dependencies whose parent pins a range that excludes the fixed version. Dependabot cannot fix those — its npm updates only bump direct dependencies — so they need an entry in `overrides` in [package.json](package.json), and they stay open indefinitely until someone adds one.
 
-Verify an override before trusting it, because a wrong one fails quietly. `npm audit` reports the resolved version and goes green whether or not the package still works, and the unit suite does not exercise most of the toolchain. Forcing `brace-expansion` to 5.x, for example, resolves cleanly and leaves all unit tests passing, but 5.x dropped the default export that `minimatch` 3 and 9 both import, so mocha throws the first time a pattern is brace-expanded. Run `make test` in full, and exercise the code path the overridden package actually sits behind.
+Nest the entry under the parent whose range you are overriding rather than declaring it at the top level. An override is a deliberate breach of a declared semver contract, and nesting it says whose contract:
+
+```json
+"overrides": { "mocha": { "serialize-javascript": "^7.0.5" } }
+```
+
+Verify an override before trusting it, because a wrong one fails quietly. `npm audit` reports the resolved version and goes green whether or not the package still works, and the unit suite does not exercise most of the toolchain. Two ways that has already bitten this repository:
+
+- Forcing `brace-expansion` to 5.x resolves cleanly and leaves all unit tests passing, but 5.x dropped the default export that `minimatch` 3 and 9 both import, so mocha throws the first time a pattern is brace-expanded.
+- mocha requires `serialize-javascript` only from its parallel worker pool, so a normal serial run never loads it at all. A broken major would have looked green everywhere. [ci.yml](.github/workflows/ci.yml) now runs the unit tests a second time under `--parallel` for no reason other than to load that one package.
+
+So run `make test` in full, then find the code path the overridden package actually sits behind and make something exercise it. A green audit is not evidence.
 
 Drop an override once the parent's own range catches up. Leaving a stale one pinned holds the tree behind the version the parent would otherwise pick.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,6 +104,22 @@ To test manually, press `F5` in VSCode to launch the Extension Development Host.
 
 > **Note:** After installing a `.vsix` file, run **Developer: Reload Window** to load the new version.
 
+#### Dependency overrides
+
+Every dependency here is a development dependency: `dependencies` is empty and [.vscodeignore](.vscodeignore) ships only the bundled `dist/`, so nothing in `node_modules` reaches a user. Security advisories against this tree are build- and test-time risks, not shipped ones, and they are still worth clearing — a clean `npm audit` is what makes the next real advisory visible.
+
+Most of them clear with a lockfile-only bump, which changes no declared range:
+
+```sh
+npm audit fix --package-lock-only
+```
+
+The rest are transitive dependencies whose parent pins a range that excludes the fixed version. Dependabot cannot fix those — its npm updates only bump direct dependencies — so they need an entry in `overrides` in [package.json](package.json), and they stay open indefinitely until someone adds one.
+
+Verify an override before trusting it, because a wrong one fails quietly. `npm audit` reports the resolved version and goes green whether or not the package still works, and the unit suite does not exercise most of the toolchain. Forcing `brace-expansion` to 5.x, for example, resolves cleanly and leaves all unit tests passing, but 5.x dropped the default export that `minimatch` 3 and 9 both import, so mocha throws the first time a pattern is brace-expanded. Run `make test` in full, and exercise the code path the overridden package actually sits behind.
+
+Drop an override once the parent's own range catches up. Leaving a stale one pinned holds the tree behind the version the parent would otherwise pick.
+
 #### Committing changes
 
 Use [conventional commits](https://www.conventionalcommits.org):

--- a/package-lock.json
+++ b/package-lock.json
@@ -203,18 +203,27 @@
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.1.1.tgz",
-      "integrity": "sha512-71grXU6+5hl+3CL3joOxlj/AW6rmhthuTlG0fRqsTrhPArQBpZuUFzCIlKOGdcafLUa/i1hBdV78ZxJdlvRA+g==",
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.4.3.tgz",
+      "integrity": "sha512-tumCMmzrRhKmTbYQg/7OlfbrIKcKaf8Ed0Fw3suUpRT3owFYljznVgxcfHe8RycQXY9uyROGiLD1GjhpF45AwA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "16.4.0",
-        "jsonwebtoken": "^9.0.0",
-        "uuid": "^8.3.0"
+        "@azure/msal-common": "16.11.3",
+        "jsonwebtoken": "^9.0.0"
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@azure/msal-node/node_modules/@azure/msal-common": {
+      "version": "16.11.3",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.11.3.tgz",
+      "integrity": "sha512-VeXOW+t3Rdd9XGX6lVyIg3DhtjMR1JD8ARKcsnGbJFUWwAmF3sHL7GwZc/ZjEUfHESResAonETRYCuG06OBT7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2660,16 +2669,16 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -4432,9 +4441,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5458,9 +5467,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {
@@ -6049,9 +6058,9 @@
       "license": "MIT"
     },
     "node_modules/mocha/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6269,9 +6278,9 @@
       "license": "MIT"
     },
     "node_modules/npm-run-all/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7102,16 +7111,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -7597,13 +7596,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.7.tgz",
+      "integrity": "sha512-YAy8Od6KV+uuwUuU50np8fGB/Aues6Y0nAhA9y/hId74PlKUcme4pXcBD46NWKr1Q4osN/iseZ17YqO1XfmI8g==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/set-function-length": {
@@ -8821,16 +8820,6 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -175,6 +175,9 @@
     "sinon": "^22.1.0",
     "typescript": "^6.0.3"
   },
+  "overrides": {
+    "serialize-javascript": "^7.0.5"
+  },
   "license": "SEE LICENSE IN LICENSE",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -128,8 +128,9 @@
     "pretest": "npm run compile-tests && npm run compile",
     "check-types": "tsc --noEmit",
     "lint": "eslint src",
-    "test": "npm run test:unit && npm run test:integration && npm run test:e2e",
+    "test": "npm run test:unit && npm run test:unit:parallel && npm run test:integration && npm run test:e2e",
     "test:unit": "mocha --require out/test/unit/setup.js out/test/unit/**/*.test.js",
+    "test:unit:parallel": "mocha --parallel --require out/test/unit/setup.js out/test/unit/**/*.test.js",
     "test:integration": "vscode-test --config .vscode-test.integration.mjs",
     "test:e2e": "vscode-test --config .vscode-test.e2e.mjs",
     "test:coverage": "c8 npm run test:unit"
@@ -176,7 +177,9 @@
     "typescript": "^6.0.3"
   },
   "overrides": {
-    "serialize-javascript": "^7.0.5"
+    "mocha": {
+      "serialize-javascript": "^7.0.5"
+    }
   },
   "license": "SEE LICENSE IN LICENSE",
   "repository": {


### PR DESCRIPTION
Closes seven open Dependabot alerts by bumping the packages they name, and records in [CONTRIBUTING.md](CONTRIBUTING.md) how to handle the next one.

## Why these were still open

The oldest of the seven has been open since February. Dependabot was never going to close any of them, and it is worth being precise about why, because the same thing will happen again.

Every affected package is transitive. This repository declares no runtime `dependencies` at all — the entire tree comes from build and test tooling — and Dependabot's npm version updates only bump the dependencies a project declares directly. Its security updates can reach a transitive package, but only by moving the parent that pins it, and here no parent release does that: `mocha` still declares `serialize-javascript` at `^6.0.2` while both advisories against it are fixed only in 7.0.5.

So the alerts sit indefinitely, and clearing them is a manual job.

## What ships

Nothing in this change reaches a user. `dependencies` is empty, and [.vscodeignore](.vscodeignore) limits the package to the bundled `dist/`, the icon, and three text files — the built `.vsix` is 8 entries with no `node_modules`:

```text
├─ [Content_Types].xml
├─ extension.vsixmanifest
└─ extension/
   ├─ LICENSE.txt, changelog.md, icon.png, package.json, readme.md
   └─ dist/extension.js
```

These are build- and test-time exposures. They are still worth clearing: a quiet `npm audit` is what makes the next advisory visible, and one that has been noisy for five months is not something anyone reads.

## The changes

Six of the seven clear with a lockfile-only bump, which changes no declared range:

| alert | package | before | after | fixed in |
| ----- | ------- | ------ | ----- | -------- |
| [#62](https://github.com/michen00/invisible-squiggles/security/dependabot/62) | `js-yaml` | 4.2.0 | 4.3.0 | 4.3.0 |
| [#57](https://github.com/michen00/invisible-squiggles/security/dependabot/57) | `brace-expansion` | 5.0.5 | 5.0.9 | 5.0.7 |
| [#60](https://github.com/michen00/invisible-squiggles/security/dependabot/60) | `brace-expansion` | 1.1.12 | 1.1.18 | 1.1.16 |
| [#61](https://github.com/michen00/invisible-squiggles/security/dependabot/61) | `brace-expansion` | 2.0.2 | 2.1.4 | 2.1.2 |
| [#42](https://github.com/michen00/invisible-squiggles/security/dependabot/42) | `uuid` | 8.3.2 | removed | 11.1.1 |

`uuid` leaves the tree entirely rather than moving: it arrived through `@azure/msal-node`, and 5.4.3 no longer depends on it.

The seventh needs an override, added to [package.json](package.json):

```json
"overrides": { "mocha": { "serialize-javascript": "^7.0.5" } }
```

`mocha` is the only package in the tree that declares a dependency on `serialize-javascript`, so nesting the entry under it resolves exactly as a top-level entry would, while naming whose declared range is deliberately being breached and leaving anything added later unbound.

That resolves 6.0.2 to 7.0.7 and closes [#26](https://github.com/michen00/invisible-squiggles/security/dependabot/26) (RCE, fixed in 7.0.3) and [#43](https://github.com/michen00/invisible-squiggles/security/dependabot/43) (CPU exhaustion, fixed in 7.0.5). Remove the override once `mocha` widens its own range; leaving it pinned would hold the tree back.

## What is deliberately not fixed

A newer advisory against `brace-expansion` — [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg), out-of-memory crash on unbounded expansion — declares every version up to 5.0.7 affected and patches only the 5.x line. There is no fixed release on 1.x or 2.x, so the copies under `npm-run-all` and `mocha` stay flagged.

Forcing all three to 5.x is not a fix. It resolves cleanly, `npm audit` goes green, and all 100 unit tests still pass — but 5.x dropped the default export, and both `minimatch` 3 (`require`) and `minimatch` 9 (`import expand from`) depend on it:

```text
TypeError: expand is not a function
    at Minimatch.braceExpand (minimatch/minimatch.js:271:10)

SyntaxError: The requested module 'brace-expansion'
             does not provide an export named 'default'
```

The first glob mocha expands throws. That failure is invisible to the unit suite, which is why the note added to CONTRIBUTING.md says to exercise the overridden package's actual code path rather than trusting a green audit.

Remaining after this change: that advisory, and a low-severity one against `diff` reachable only by downgrading `mocha`.

## Exercising the override

An override that resolves is not an override that works, and this one sat behind a code path no test ran. `mocha` requires `serialize-javascript` from exactly one file, `lib/nodejs/buffered-worker-pool.js`, reached only under `--parallel`. Every test job here is serial, so the package was installed and never loaded — it is absent from `require.cache` after a normal run. A breaking major would have reached main with every check green.

So [ci.yml](.github/workflows/ci.yml) now runs the unit suite a second time under `--parallel`, for no reason other than loading that one package, and `npm test` does the same locally. It costs about 150 ms.

## Verification

- `make check` — compile, lint, unit tests serial and parallel, integration, E2E, plus the `prepare-readme.sh` and `normalize-vsix.mjs` script tests
- `make verify-reproducible` — builds under umask 022 and 077 are still byte-identical
- `npm ls` confirms every resolved version listed above, and a from-scratch resolve in an empty directory with only the nested override confirms it reaches 7.0.7 on its own
- `make run-pre-commit` — clean

## Relationship to the release

This is a pre-release chore. It does not touch the changelog: `build` commits are skipped by [cliff.toml](cliff.toml), and correctly so, since no user-visible behaviour changes. [#232](https://github.com/michen00/invisible-squiggles/pull/232) has since merged, and this branch has been updated with it.
