### PR TITLE
ci: stop asset upload from blocking publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -140,12 +140,40 @@ jobs:
         with:
           subject-path: ${{ steps.build.outputs.vsix }}
 
+      # Best-effort, and deliberately non-fatal. The registries below are the
+      # release; a missing download convenience on the release page is not a
+      # reason to skip them. Before this guard existed, a refused upload took
+      # both publish steps down with it and a tagged, announced release shipped
+      # to neither registry.
+      #
+      # Immutable releases are enabled for this repository, and they freeze a
+      # release's assets at the moment it is published. This job only runs after
+      # that point -- its trigger is `release: published` -- and the asset does
+      # not exist until the build step above produces it, so no ordering of these
+      # steps can attach one. GitHub refuses the upload with HTTP 422. Restoring
+      # the asset means creating the release as a draft, uploading, and only then
+      # publishing: a change to who creates the release, not to this step.
+      #
+      # Nothing becomes unrecoverable. `make verify-reproducible` rebuilds the
+      # exact bytes from the tag, and the attestation above covers them.
       - name: Attach the VSIX to the release
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
           TAG: ${{ steps.metadata.outputs.tag }}
           VSIX: ${{ steps.build.outputs.vsix }}
-        run: gh release upload "${TAG}" "${VSIX}" --clobber
+        run: |
+          # Skipping a release already known to be frozen keeps a genuine failure
+          # -- bad credentials, a missing file, a network fault -- visible as a
+          # failed step, rather than teaching everyone to ignore a red mark that
+          # appears on every single release.
+          if [ "$(gh api "repos/${REPO}/releases/tags/${TAG}" --jq '.immutable')" = "true" ]; then
+            echo "::notice::${TAG} is immutable; assets froze when it was" \
+              "published. Skipping upload."
+            exit 0
+          fi
+          gh release upload "${TAG}" "${VSIX}" --clobber
 
       # Azure DevOps retires global PATs on 2026-12-01, and a global PAT is the
       # only kind that can reach the Marketplace today. Setting the AZURE_*


### PR DESCRIPTION
## What broke

`v0.4.0` was tagged, released, and announced. It shipped to neither the VS Code Marketplace nor Open VSX.

[Run 30610383229](https://github.com/michen00/invisible-squiggles/actions/runs/30610383229) built the VSIX, proved it reproducible, and minted a valid provenance attestation — then died one step later and skipped both publish steps:

```
7. Build VSIX and verify reproducibility  success
8. Attest build provenance                success
9. Attach the VSIX to the release         failure   <-- HTTP 422
10. Authenticate to Microsoft Entra ID    skipped
11. Publish to VS Code Marketplace        skipped
12. Publish to Open VSX                   skipped
```

```
HTTP 422: Cannot upload assets to an immutable release.
```

## Why it cannot be fixed by reordering

This repository has **immutable releases** enabled, which freeze a release's assets at the instant it is published. Both existing releases report `isImmutable: true`.

The publish job's trigger is `release: published`, so it only ever runs *after* the freeze — and the VSIX it wants to attach does not exist until the build step inside that same job produces it. There is no ordering of these steps that puts the upload before the publish. The step could never have succeeded; `v0.4.0` was simply the first release to reach it, since the workflow itself landed in #228 after `v0.3.1` shipped.

Restoring an asset on the release page would mean creating the release as a draft, uploading to it, and only then publishing. That is a change to *who creates the release* — today `make release` does — not a change to this step, so it is left for a follow-up.

## What this changes

The upload becomes non-fatal, and is skipped outright when the release is already known to be frozen.

Both halves matter. `continue-on-error` alone would leave one step red on every single release, which is how a real credential or network failure gets waved through as "the usual red one". Skipping the known-frozen case keeps the red mark meaningful.

## What is not lost

Dropping the release asset costs a download convenience, not recoverability:

- `make verify-reproducible` rebuilds byte-identical output from the tag — the same property the partial-retry path already depends on.
- The attestation minted in step 8 covers those bytes, and verifies against a copy fetched from either registry:
  ```
  gh attestation verify invisible-squiggles-0.4.0.vsix --repo michen00/invisible-squiggles
  ```

## Publishing v0.4.0

The pending publish does not wait on this PR merging. `workflow_dispatch` reads the workflow definition from whatever ref it is dispatched on, while the job's `actions/checkout` step pins `ref: <tag>` — so dispatching from this branch with `tag: v0.4.0` ships bytes built from the `v0.4.0` tag, not from this branch.
