### PR TITLE
ci: publish registries independently

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -262,10 +262,17 @@ jobs:
             case "${outcome}" in
               success) echo "${registry}: published." ;;
               skipped) echo "${registry}: not requested." ;;
+              # Names the outcome and sends the reader to the log, rather than
+              # naming a cause. This annotation is the first thing a responder
+              # sees, and bad credentials, a registry outage, a rejected
+              # package, and a network fault all arrive here identically -- so
+              # guessing between them here would just point at the wrong repair
+              # most of the time.
               *)
-                echo "::error::${registry}: ${outcome}. Fix the credentials," \
-                  "then re-dispatch this workflow with targets set to" \
-                  "this registry alone."
+                echo "::error::${registry}: publish did not succeed" \
+                  "(${outcome}). Read that step's log for the cause. Once it" \
+                  "is addressed, re-dispatch this workflow with targets set" \
+                  "to this registry alone."
                 failed=1
                 ;;
             esac

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -194,7 +194,21 @@ jobs:
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           allow-no-subscriptions: true
 
+      # The two registries are independent services holding independent
+      # credentials, so neither may withhold the release from the other. Both
+      # publishes are therefore non-fatal *as steps*, and the gate below turns
+      # either failure back into a failed job.
+      #
+      # This is not hypothetical. On v0.4.0 an unusable Marketplace PAT failed
+      # this step, which skipped Open VSX behind it -- whose own credentials were
+      # never even tried -- and the release reached neither registry.
+      #
+      # Recover a partial publish by re-dispatching with `targets` set to
+      # whichever registry is missing. The build above is reproducible, so the
+      # retry ships bytes identical to the ones that already landed.
       - name: Publish to VS Code Marketplace
+        id: vscode
+        continue-on-error: true
         if: contains(fromJSON('["both", "vscode"]'), steps.metadata.outputs.targets)
         env:
           ENTRA: ${{ steps.entra.outcome }}
@@ -214,7 +228,11 @@ jobs:
           fi
 
       - name: Publish to Open VSX
-        if: contains(fromJSON('["both", "openvsx"]'), steps.metadata.outputs.targets)
+        id: openvsx
+        continue-on-error: true
+        if: >-
+          !cancelled() &&
+          contains(fromJSON('["both", "openvsx"]'), steps.metadata.outputs.targets)
         env:
           OVSX_PAT: ${{ secrets['OVSX_PAT'] }}
           VSIX: ${{ steps.build.outputs.vsix }}
@@ -224,3 +242,32 @@ jobs:
             exit 1
           fi
           npx ovsx publish "${VSIX}"
+
+      # `continue-on-error` hides a failed publish from the job's own status, so
+      # without this step a release that reached neither registry would report
+      # success -- trading the old failure mode for a quieter, worse one.
+      #
+      # A skipped step means the registry was not requested, which is not a
+      # failure. Only a requested target that did not publish fails the job.
+      - name: Verify every requested registry published
+        if: '!cancelled()'
+        env:
+          OPENVSX: ${{ steps.openvsx.outcome }}
+          VSCODE: ${{ steps.vscode.outcome }}
+        run: |
+          failed=0
+          for entry in "VS Code Marketplace:${VSCODE}" "Open VSX:${OPENVSX}"; do
+            registry="${entry%:*}"
+            outcome="${entry##*:}"
+            case "${outcome}" in
+              success) echo "${registry}: published." ;;
+              skipped) echo "${registry}: not requested." ;;
+              *)
+                echo "::error::${registry}: ${outcome}. Fix the credentials," \
+                  "then re-dispatch this workflow with targets set to" \
+                  "this registry alone."
+                failed=1
+                ;;
+            esac
+          done
+          exit "${failed}"


### PR DESCRIPTION
## What broke

The VS Code Marketplace and Open VSX are independent services holding independent credentials, but the publish steps sat in sequence with nothing between them. A Marketplace failure aborted the job and skipped Open VSX behind it.

`v0.4.0` hit exactly that. [Run 30611448141](https://github.com/michen00/invisible-squiggles/actions/runs/30611448141):

```
11. Publish to VS Code Marketplace  failure   <-- TF400813, unusable PAT
12. Publish to Open VSX             skipped
```

```
Publishing 'michen00.invisible-squiggles v0.4.0'...
TF400813: The user 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' is not authorized to access this resource.
```

A tagged, released, and announced version reached neither registry — and Open VSX's own credentials were never tried. They were fine: dispatching `targets: openvsx` by itself published `0.4.0` on the first attempt, seconds of runtime later.

## What this changes

Both publishes become non-fatal *as steps*, so neither registry can withhold the release from the other, and a new gate fails the job when a requested registry did not publish.

The gate is the point. `continue-on-error` on its own would trade a loud failure for a silent one — a release that reached nowhere would report success, which is strictly worse than what it replaces. A `skipped` step means the registry was not requested, which is not a failure; only a requested target that did not publish fails the job.

Outcomes:

| `targets` | Marketplace | Open VSX | Job |
| --- | --- | --- | --- |
| `both` | published | published | pass |
| `both` | **failed** | published | **fail**, and Open VSX still has the release |
| `both` | published | **failed** | **fail**, and the Marketplace still has the release |
| `openvsx` | not requested | published | pass |

## Recovering a partial publish

Unchanged, and now actually reachable: re-dispatch with `targets` set to whichever registry is missing. The build is reproducible, so the retry ships bytes identical to the ones that already landed — which is what makes a half-published release safe to complete rather than something to work around with a version bump.
