### PR TITLE
ci: draft releases so they carry the vsix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,15 @@
 ---
 name: publish extension
 on:
+  # Drafts the release. Immutable releases freeze a release's assets the moment
+  # it is published, so the VSIX has to be attached before that -- which means
+  # the release must start as a draft, and the thing that builds the VSIX has to
+  # be the thing that creates it. A tag push therefore lands here, builds,
+  # attests, and leaves a draft. It publishes to no registry.
+  push:
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
+  # Publishes it. Reached by publishing that draft, which `make release` does.
   release:
     types: [published]
   workflow_dispatch:
@@ -20,11 +29,13 @@ on:
           - openvsx
 
 concurrency:
-  group: publish-${{ github.event.release.tag_name || inputs.tag }}
+  # Keyed on the tag, not the event, so the draft run and the publish run for one
+  # version queue behind each other instead of racing.
+  group: publish-${{ github.event.release.tag_name || inputs.tag || github.ref_name }}
   cancel-in-progress: false
 
 permissions:
-  # Attaching the VSIX to the release.
+  # Creating the draft release and attaching the VSIX to it.
   contents: write
   # Mints the OIDC token, used both for the provenance attestation and for
   # Entra ID federated auth.
@@ -41,7 +52,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.release.tag_name || inputs.tag }}
+          ref: >-
+            ${{ github.event.release.tag_name || inputs.tag
+            || github.ref_name }}
 
       - name: Resolve release metadata
         id: metadata
@@ -49,15 +62,30 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           INPUT_TAG: ${{ inputs.tag }}
           INPUT_TARGETS: ${{ inputs.targets }}
+          PUSHED_TAG: ${{ github.ref_name }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          if [ "${EVENT_NAME}" = "release" ]; then
-            tag="${RELEASE_TAG}"
-            targets="both"
-          else
-            tag="${INPUT_TAG}"
-            targets="${INPUT_TARGETS}"
-          fi
+          case "${EVENT_NAME}" in
+            # `targets=none` is load-bearing, not a placeholder. Both publish
+            # steps test membership in a list that does not contain it, so a tag
+            # push cannot reach a registry no matter what else changes -- and the
+            # gate at the end still runs, which is what proves it didn't.
+            push)
+              tag="${PUSHED_TAG}"
+              targets="none"
+              mode="draft"
+              ;;
+            release)
+              tag="${RELEASE_TAG}"
+              targets="both"
+              mode="publish"
+              ;;
+            *)
+              tag="${INPUT_TAG}"
+              targets="${INPUT_TARGETS}"
+              mode="publish"
+              ;;
+          esac
           case "${tag}" in
             v[0-9]*.[0-9]*.[0-9]*) ;;
             *)
@@ -65,9 +93,12 @@ jobs:
               exit 1
               ;;
           esac
-          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
-          echo "targets=${targets}" >> "$GITHUB_OUTPUT"
-          echo "Publishing ${tag} to: ${targets}"
+          {
+            echo "tag=${tag}"
+            echo "targets=${targets}"
+            echo "mode=${mode}"
+          } >> "$GITHUB_OUTPUT"
+          echo "${mode}: ${tag} -> ${targets}"
 
       # Pinned exactly, unlike the floating 22.x elsewhere in CI. The retry path
       # below depends on a rebuild of a tag producing identical bytes, and the
@@ -140,40 +171,53 @@ jobs:
         with:
           subject-path: ${{ steps.build.outputs.vsix }}
 
-      # Best-effort, and deliberately non-fatal. The registries below are the
-      # release; a missing download convenience on the release page is not a
-      # reason to skip them. Before this guard existed, a refused upload took
-      # both publish steps down with it and a tagged, announced release shipped
-      # to neither registry.
+      # The draft half of the release, and the only point at which an asset can
+      # be attached: immutable releases freeze assets when a release is
+      # published, so anything not on it by then never will be. This runs before
+      # the release exists, which is the whole reason a tag push triggers this
+      # workflow at all.
       #
-      # Immutable releases are enabled for this repository, and they freeze a
-      # release's assets at the moment it is published. This job only runs after
-      # that point -- its trigger is `release: published` -- and the asset does
-      # not exist until the build step above produces it, so no ordering of these
-      # steps can attach one. GitHub refuses the upload with HTTP 422. Restoring
-      # the asset means creating the release as a draft, uploading, and only then
-      # publishing: a change to who creates the release, not to this step.
+      # Publishing the draft afterwards -- `make release VERSION=vX.Y.Z`, or the
+      # button in the web UI -- freezes it with the artifact in place and fires
+      # the `release: published` half of this same workflow, which ships those
+      # bytes to the registries.
       #
-      # Nothing becomes unrecoverable. `make verify-reproducible` rebuilds the
-      # exact bytes from the tag, and the attestation above covers them.
-      - name: Attach the VSIX to the release
-        continue-on-error: true
+      # Nothing here can publish anything. `targets` is `none` on this path.
+      - name: Draft the release with the VSIX attached
+        if: steps.metadata.outputs.mode == 'draft'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
           TAG: ${{ steps.metadata.outputs.tag }}
           VSIX: ${{ steps.build.outputs.vsix }}
         run: |
-          # Skipping a release already known to be frozen keeps a genuine failure
-          # -- bad credentials, a missing file, a network fault -- visible as a
-          # failed step, rather than teaching everyone to ignore a red mark that
-          # appears on every single release.
-          if [ "$(gh api "repos/${REPO}/releases/tags/${TAG}" --jq '.immutable')" = "true" ]; then
-            echo "::notice::${TAG} is immutable; assets froze when it was" \
-              "published. Skipping upload."
-            exit 0
-          fi
-          gh release upload "${TAG}" "${VSIX}" --clobber
+          # `absent` on any read failure, so an unreadable release is treated as
+          # one to create -- `gh release create` then fails loudly on a genuine
+          # conflict, which beats silently skipping the attach and leaving a
+          # release that looks finished and carries nothing.
+          state=$(gh release view "${TAG}" --json isDraft --jq '.isDraft' \
+            2>/dev/null || echo absent)
+          case "${state}" in
+            absent)
+              gh release create "${TAG}" --draft --generate-notes \
+                --verify-tag "${VSIX}"
+              echo "::notice::Drafted ${TAG} with ${VSIX}. Review it, then" \
+                "publish with: make release VERSION=${TAG}"
+              ;;
+            true)
+              # Re-running against an existing draft refreshes the asset instead
+              # of failing. The rebuild is byte-identical, so this is a no-op in
+              # the ordinary case and a repair when a first upload was cut short.
+              gh release upload "${TAG}" "${VSIX}" --clobber
+              echo "::notice::Refreshed ${VSIX} on the existing ${TAG} draft."
+              ;;
+            *)
+              # Published, therefore frozen. There is nothing to attach and
+              # nothing to repair; a run that built correctly should not fail
+              # over a door that closed on purpose.
+              echo "::warning::${TAG} is already published, so its assets are" \
+                "frozen. Leaving the release alone."
+              ;;
+          esac
 
       # Azure DevOps retires global PATs on 2026-12-01, and a global PAT is the
       # only kind that can reach the Marketplace today. Setting the AZURE_*
@@ -219,7 +263,9 @@ jobs:
             echo "Publishing with Entra ID federated credentials."
             npx vsce publish --azure-credential --packagePath "${VSIX}"
           elif [ -n "${VSCE_PAT}" ]; then
-            echo "Publishing with VSCE_PAT. Migrate to Entra ID before 2026-12-01."
+            echo "::warning::Publishing with VSCE_PAT. Azure retires global" \
+              "PATs on 2026-12-01, after which this stops working. Migrate to" \
+              "Entra ID: see issue #242."
             npx vsce publish --packagePath "${VSIX}"
           else
             echo "Error: no Marketplace credentials. Set the AZURE_CLIENT_ID and"
@@ -249,6 +295,10 @@ jobs:
       #
       # A skipped step means the registry was not requested, which is not a
       # failure. Only a requested target that did not publish fails the job.
+      #
+      # Left running on the draft path deliberately, where it reports both
+      # registries as not requested. That is the assertion that a tag push
+      # published nothing, printed in the run itself rather than assumed.
       - name: Verify every requested registry published
         if: '!cancelled()'
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,11 @@ on:
   # be the thing that creates it. A tag push therefore lands here, builds,
   # attests, and leaves a draft. It publishes to no registry.
   push:
+    # Glob, not regex, but `+` is still a quantifier here: GitHub's filter
+    # patterns read it as one or more of the preceding element, so this is one
+    # or more digits per position. Deliberately stricter than the `[0-9]*` form
+    # used by the shell validation below, where `*` is any-characters and would
+    # also admit v1abc.2.3.
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
   # Publishes it. Reached by publishing that draft, which `make release` does.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,13 +185,18 @@ Editing a merged PR's description is fine and worth doing when it turns out to b
       is unsigned and `make verify-tag` will fail on it. Confirm with
       `make verify-tag VERSION=vX.Y.Z` before pushing.
 11. Push with tags: `git push --follow-tags`
-12. Create a GitHub release from the tag: `make release VERSION=vX.Y.Z`
-13. Review the release notes and edit them if needed (via GitHub web UI).
-14. The `publish extension` workflow fires on `release: published` and does the rest: it builds one VSIX, attests it, attaches it to the release, and publishes that same file to the VSCode Marketplace and Open VSX.
+12. That push starts the `publish extension` workflow in **draft** mode: it builds one VSIX, proves it reproducible, attests it, and leaves a draft release carrying that exact file. Nothing reaches a registry on this path.
+13. Review the draft. The generated notes and the attested artifact are both sitting there to be looked at, and a draft can still be deleted — nothing is committed to yet. Edit the notes in the web UI if they need it.
+14. Publish it: `make release VERSION=vX.Y.Z`. **This is the irreversible step.** It freezes the release with its asset, starts the Announcements discussion, and fires the same workflow again, which ships that build to the VSCode Marketplace and Open VSX. Neither registry allows replacing a published version.
 
 ### Publishing
 
-Releases publish themselves. `.github/workflows/publish.yml` verifies the tag matches `package.json`, builds the VSIX once via `make package-vsix` (so marketplace README preparation happens exactly one way), then publishes to both registries.
+`.github/workflows/publish.yml` runs twice per release, once per half, and the split exists because of immutable releases: they freeze a release's assets the instant it is published, so the VSIX has to be attached before that, by the thing that builds it.
+
+- **Tag push → draft.** Verifies the tag matches `package.json`, builds the VSIX once via `make package-vsix` (so marketplace README preparation happens exactly one way), proves the build reproducible, attests it, and drafts the release around it. `targets` is `none` here, so neither publish step can run — and the verification gate still executes, reporting both registries as not requested, which is what evidences that.
+- **Release published → registries.** The same build, re-derived from the same tag and therefore byte-identical, goes to both registries independently. A failure in one does not withhold the other, and the gate at the end fails the job for any requested registry that did not publish.
+
+Publishing the draft is what connects the two, and it is a human action by design: `make release` refuses to run unless a draft exists and carries a `.vsix`, since publishing a draft without one would freeze it empty.
 
 Repository secrets required:
 

--- a/Makefile
+++ b/Makefile
@@ -248,15 +248,35 @@ verify-tag: ## Verify a release tag's signature (VERSION=vX.Y.Z)
 	@if [ -z "$(VERSION)" ]; then echo "Usage: make verify-tag VERSION=vX.Y.Z"; exit 1; fi
 	@git -c gpg.ssh.allowedSignersFile=$(SIGNERS_FILE) verify-tag $(VERSION)
 
-# The publish workflow owns artifact upload: it builds the VSIX once, attests
-# that exact file, publishes it, and attaches it to the release. Building or
-# uploading here as well would mean the attested bytes are not the shipped bytes.
+# Publishes the draft that pushing the tag already created; it does not create a
+# release. The publish workflow owns the artifact end to end -- it builds the VSIX
+# once, attests that exact file, and attaches it to the draft -- because building
+# or uploading here too would mean the attested bytes are not the shipped bytes.
+#
+# This is still the release gate, and still the irreversible step: publishing the
+# draft freezes it and fires the workflow that pushes to both registries, neither
+# of which allows replacing a published version. What changed is that the draft
+# now exists first, so the gate can be walked up to and looked at.
 .PHONY: release
-release: ## Create a GitHub release (VERSION=vX.Y.Z)
+release: ## Publish the drafted release (VERSION=vX.Y.Z)
 	@if [ -z "$(VERSION)" ]; then echo "Usage: make release VERSION=vX.Y.Z"; exit 1; fi
 	@git rev-parse --verify refs/tags/$(VERSION) >/dev/null 2>&1 || { echo "Error: Tag $(VERSION) does not exist"; exit 1; }
-	gh release create $(VERSION) --generate-notes --discussion-category "Announcements"
-	@echo "The publish workflow attests, publishes, and attaches the VSIX."
+	@gh release view $(VERSION) --json isDraft --jq .isDraft 2>/dev/null | grep -qx true || { \
+		echo "Error: no draft release for $(VERSION)."; \
+		echo "Push the tag and let the publish workflow draft it:"; \
+		echo "  git push --follow-tags"; \
+		echo "Already published? Then it is done, or retry a registry with:"; \
+		echo "  gh workflow run publish.yml -f tag=$(VERSION) -f targets=both"; \
+		exit 1; }
+	@gh release view $(VERSION) --json assets --jq '.assets[].name' | grep -q '\.vsix$$' || { \
+		echo "Error: the $(VERSION) draft carries no VSIX."; \
+		echo "Publishing now would freeze it that way -- assets cannot be added"; \
+		echo "to a published release, though a draft still accepts them."; \
+		echo "Re-trigger the draft build (same tag object, same signature):"; \
+		echo "  git push --delete origin $(VERSION) && git push origin $(VERSION)"; \
+		exit 1; }
+	gh release edit $(VERSION) --draft=false --discussion-category "Announcements"
+	@echo "Published $(VERSION). The publish workflow now ships it to both registries."
 
 .PHONY: test
 # Chained under one `set -e`. This file sets .ONESHELL, so the whole recipe goes


### PR DESCRIPTION
## Why v0.4.0's release page is empty

Immutable releases freeze a release's assets the instant it is published. The publish workflow's trigger is `release: published`, so it only ran after the freeze — and the VSIX it wanted to attach did not exist until a step inside that same job built it. There was no ordering that could work. GitHub refused every upload with `HTTP 422: Cannot upload assets to an immutable release`, and on v0.4.0 that refusal also took both publish steps down with it, so the release reached neither registry on its first attempt.

#240 stopped the cascade and #241 made the registries independent. Neither of them could put an asset on a release, because that is not a workflow-ordering problem — it is a question of *who creates the release*.

## What changes

A tag push now enters this same workflow in **draft mode**:

| Trigger | `mode` | `targets` | What it does |
| --- | --- | --- | --- |
| `push` on `v*.*.*` | `draft` | `none` | build, verify reproducible, attest, draft the release around that file |
| `release: published` | `publish` | `both` | rebuild the same tag, attest, ship to both registries |
| `workflow_dispatch` | `publish` | your choice | same, scoped to one registry for retries |

`targets: none` is load-bearing rather than cosmetic. Both publish steps test list membership that excludes it, so a tag push cannot reach a registry no matter what else drifts — and the verification gate from #241 is deliberately left running on that path, where it reports both registries as *not requested*. The run therefore evidences that it published nothing instead of that being an assumption about it.

The old attach-and-skip step is gone. It existed only to fail politely against a door that closes on purpose, and the draft path replaces it.

## `make release` publishes, it no longer creates

```
git push --follow-tags          # → draft release appears, with the VSIX on it
                                #   nothing published anywhere yet
make release VERSION=vX.Y.Z     # → freezes it, starts the discussion,
                                #   fires the registry publish
```

Same two beats as before. The difference is that the second one now happens in front of the generated notes and the attested artifact, instead of ahead of them — previously there was nothing to look at until it was too late to look. Inspecting stays optional; having the option does not.

It also refuses to run on a draft that carries no VSIX, since publishing an empty draft would freeze it empty — the exact outcome this PR exists to prevent.

## Verification

The interesting paths are ones a green release never exercises, so they were run directly rather than reasoned about.

Metadata resolution, all four cases:

```
push v0.4.1            → tag=v0.4.1 targets=none    mode=draft     rc=0
release published      → tag=v0.4.1 targets=both    mode=publish   rc=0
dispatch openvsx       → tag=v0.4.1 targets=openvsx mode=publish   rc=0
push of tag "nightly"  → Error: not of the form vX.Y.Z             rc=1
```

The draft step against each release state it can encounter:

```
absent → gh release create --draft --generate-notes --verify-tag <vsix>
draft  → gh release upload --clobber          (byte-identical rebuild; repairs a cut-short upload)
published → warning, leaves it alone          (frozen; nothing to attach, nothing to fix)
```

The new `make release` guards, run for real against the already-published v0.4.0 and a nonexistent tag — both refused before reaching `gh release edit`:

```
$ make release VERSION=v0.4.0
Error: no draft release for v0.4.0.
Push the tag and let the publish workflow draft it: …
$ make release VERSION=v9.9.9
Error: Tag v9.9.9 does not exist
```

`gh release edit --discussion-category` documents itself as *"Start a discussion in the specified category when publishing a draft"*, so the Announcements discussion survives the move.

## Known limitation

This cannot be dry-run end to end. The build step verifies the tag against `package.json`, so a throwaway `v0.0.0-test` tag fails before reaching the draft logic. First live exercise is v0.4.1.

That is deliberately the cheap direction to be wrong in: a bug on the draft path leaves a draft release, which is deletable. The alternative design — a tag push that publishes straight through to both registries — would have made the same bug a permanently published version.

## Also here

The `VSCE_PAT` fallback notice becomes a `::warning::` annotation, so the 2026-12-01 global-PAT retirement shows up in the run summary during a release rather than only in a log nobody opens when things are going well. Tracked in #242.
