### PR TITLE
docs: document settings, add security policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,34 @@ Click the **👁️ Toggle Squiggles** button at the **bottom right**.
 1. Type **`Toggle Squiggles`**.
 1. Select the command to hide/show squiggles.
 
-<!-- TODO: Add instructions for mapping a shortcut. -->
+### **Option 3: Using a Keyboard Shortcut**
+
+There is no default shortcut, so pick one that suits you:
+
+1. Press **`Ctrl/Cmd + K`** then **`Ctrl/Cmd + S`** to open Keyboard Shortcuts.
+1. Search for **`Toggle Squiggles`**.
+1. Click the **+** beside it and press your key combination.
+
+Or add it to `keybindings.json` yourself:
+
+```json
+{ "key": "ctrl+alt+s", "command": "invisible-squiggles.toggle" }
+```
+
+## 🔹 Settings
+
+Everything lives under `invisibleSquiggles` and applies globally.
+
+| Setting                | Default | Effect                                           |
+| ---------------------- | ------- | ------------------------------------------------ |
+| `hideErrors`           | `true`  | Hide error squiggles when toggling.              |
+| `hideWarnings`         | `true`  | Hide warning squiggles when toggling.            |
+| `hideInfo`             | `true`  | Hide info squiggles when toggling.               |
+| `hideHint`             | `true`  | Hide hint squiggles when toggling.               |
+| `showStatusBarMessage` | `false` | Show a brief status bar message on each toggle.  |
+| `startHidden`          | `false` | Hide squiggles automatically when VSCode starts. |
+
+The four `hide*` settings choose which squiggle types the toggle acts on — this is the "independently control" part. Set `hideErrors` to `false` and errors stay visible while warnings, info, and hints disappear. Turn all four off and the toggle has nothing to act on.
 
 ## ⚠️ Important Notes
 
@@ -59,15 +86,8 @@ Click the **👁️ Toggle Squiggles** button at the **bottom right**.
 - **Customizations stored in settings**: Your original color customizations are saved in VS Code's `settings.json`. If this file becomes corrupted, your saved customizations may be lost.
 - Users who upgrade while squiggles are hidden may need to toggle twice to reset state.
 
-## 🔹 Verifying a release
-
-Releases carry keyless build provenance, and release tags from v0.2.1 onward are signed:
-
-```bash
-gh attestation verify invisible-squiggles-<version>.vsix --repo michen00/invisible-squiggles
-git -c gpg.ssh.allowedSignersFile=.github/allowed_signers verify-tag v<version>
-```
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for what each one proves.
-
 ## 🔹 Documentation [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/michen00/invisible-squiggles)
+
+- [CONTRIBUTING.md](CONTRIBUTING.md) — development setup, the release process, and the dependency-override policy
+- [SECURITY.md](SECURITY.md) — reporting a vulnerability, what the extension can touch, and how to verify a release you installed
+- [CHANGELOG.md](CHANGELOG.md) — release history

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,44 @@
+# Security policy
+
+## Reporting a vulnerability
+
+Report it privately: **[open a draft security advisory](https://github.com/michen00/invisible-squiggles/security/advisories/new)**. Private vulnerability reporting is enabled on this repository, so the report stays between you and the maintainer until there is a fix to publish.
+
+Please don't open a public issue for a suspected vulnerability.
+
+Include whatever you would want if you were the one fixing it: the extension version, your editor and its version, and the smallest reproduction you can manage.
+
+## Supported versions
+
+Fixes go into the next release. Older versions are not patched, because both registries refuse to replace a version that already exists — the only way to ship a fix is to release forward.
+
+## What this extension can reach
+
+Worth stating plainly, since the extension's whole job is editing your settings.
+
+It writes to your **global** `settings.json`, and only two namespaces within it: `workbench.colorCustomizations`, where it sets diagnostic squiggle colours to transparent and restores them, and `invisibleSquiggles.*`, its own configuration. It reads the rest of `workbench.colorCustomizations` solely to preserve customizations that aren't its own.
+
+It makes no network requests, spawns no processes, and reads no files. It has no runtime dependencies at all — `dependencies` in [package.json](package.json) is empty, and the packaged extension contains only a bundled `dist/`, so nothing from `node_modules` reaches your machine.
+
+The consequence worth knowing is in the README: while squiggles are hidden, manual edits to those specific colour keys get overwritten on the next toggle.
+
+## Verifying a release
+
+Two independent checks that prove different things.
+
+**The source.** Release tags from v0.2.0 onward are signed. A signed annotated tag commits to the exact source tree through git's hash chain, and the trusted public key is committed to [.github/allowed_signers](.github/allowed_signers), so this works offline from a clone:
+
+```sh
+git config gpg.ssh.allowedSignersFile .github/allowed_signers
+git verify-tag vX.Y.Z
+```
+
+**The artifact.** Every release is built once in GitHub Actions and attested with [`actions/attest-build-provenance`](https://github.com/actions/attest-build-provenance) — GitHub OIDC plus sigstore, no signing secret anywhere. Run this against a `.vsix` taken from either registry or from the release page:
+
+```sh
+gh attestation verify invisible-squiggles-<version>.vsix --repo michen00/invisible-squiggles
+```
+
+Neither substitutes for the other. The VSIX ships a minified bundle and no source, so provenance proves _this bundle was built by this repository's CI at this commit_, while the signed tag proves _this is the source the maintainer released_. Bridging them is the build being reproducible: `make verify-reproducible` packages twice under different umasks and fails if the bytes differ, so the same tag rebuilt elsewhere yields the artifact that was attested.
+
+See [CONTRIBUTING.md](CONTRIBUTING.md#creating-a-release) for how releases are cut.


### PR DESCRIPTION
The README is also the VS Code Marketplace and Open VSX listing. It was carrying something written for contributors while omitting the things a reader deciding whether to install would want.

## What was missing

**None of the six settings were documented anywhere a user looks.** The Features list promises *"Independently control hint, info, warning, and error squiggles"* and then never says how, which leaves the headline claim unactionable — the reader has no way to discover `invisibleSquiggles.hideErrors` exists. There is now a table of all six, and a sentence explaining that the four `hide*` flags select which types the toggle acts on.

**Keybinding instructions**, resolving a standing `<!-- TODO -->`. The extension contributes no default keybinding, so without this a reader has no way to know one is bindable at all.

## What was wrong for the audience

The `## 🔹 Verifying a release` section sat above the strip point, so it shipped to both listings — a page read by people deciding whether to install.

Half of it could not run there:

```bash
git -c gpg.ssh.allowedSignersFile=.github/allowed_signers verify-tag v<version>
```

That path is inside a clone. Someone on the Marketplace listing does not have one. And the section closed by pointing at CONTRIBUTING.md for what the checks prove — a contributor document, on a consumer page.

## Where it went instead

A new [SECURITY.md](SECURITY.md), which is where someone evaluating the extension actually looks and where GitHub links from the repository's Security tab. Private vulnerability reporting is already enabled, so it points at the draft-advisory flow rather than an email address.

It also writes down something that existed nowhere and matters more to most readers than the checksums do — **what the extension can reach.** Verified against the source rather than assumed:

| Claim | Checked by |
| --- | --- |
| Only touches `workbench.colorCustomizations` and `invisibleSquiggles.*` | the only two `getConfiguration(...)` namespaces in `src/extension.ts` |
| No network, no processes, no file reads | no `fetch`/`http`/`child_process`/`exec`/`spawn`/`fs.` anywhere in `src` |
| No runtime dependencies | `dependencies` in package.json is `{}` |

**One correction while moving it:** the README claimed tags are signed "from v0.2.1 onward". v0.2.0 is signed too — checked across every tag, v0.1.0 and v0.1.1 are the unsigned ones. SECURITY.md says v0.2.0.

## Placement is load-bearing

`scripts/prepare-readme.sh` strips from the Documentation heading to end of file, so the cut point decides what reaches a listing:

- **Settings** sits above it, and ships.
- The new **documentation index** (CONTRIBUTING / SECURITY / CHANGELOG) sits below it, and stays in the repository where those links belong.

Verified by running the script against the new README — what ships is Features → Quickstart (three options) → Settings → Important Notes, with no verification section and no CONTRIBUTING pointer beyond the pre-existing "PRs Welcome" badge.

## Not included

The other README TODO — re-recording the demo GIF, which predates the 👁️ status bar icon and is now the listing's most out-of-date element. That needs a screen recording, so it is deliberately left for a follow-up.
