### PR TITLE
chore: release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com) and this p
 
 ## [Unreleased]
 
-## [0.4.1](https://github.com/michen00/invisible-squiggles/compare/v0.4.0..v0.4.1) - 2026-08-03
+## [0.4.1](https://github.com/michen00/invisible-squiggles/compare/v0.4.0..v0.4.1) - 2026-08-04
 
 No functional changes. The extension behaves exactly as it did in 0.4.0.
 
@@ -16,7 +16,7 @@ No functional changes. The extension behaves exactly as it did in 0.4.0.
 
 - Document all six `invisibleSquiggles.*` settings, which were previously discoverable only through the Settings UI - ([#248](https://github.com/michen00/invisible-squiggles/pull/248))
 - Add instructions for binding a keyboard shortcut to **Toggle Squiggles**; the extension ships no default binding - ([#248](https://github.com/michen00/invisible-squiggles/pull/248))
-- Add [SECURITY.md](https://github.com/michen00/invisible-squiggles/blob/main/SECURITY.md), covering vulnerability reporting, what the extension can reach, and how to verify a release - ([#248](https://github.com/michen00/invisible-squiggles/pull/248))
+- Add [SECURITY.md](https://github.com/michen00/invisible-squiggles/blob/b57143d/SECURITY.md), covering vulnerability reporting, what the extension can reach, and how to verify a release - ([#248](https://github.com/michen00/invisible-squiggles/pull/248))
 
 ### 💚 Release pipeline
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com) and this p
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/michen00/invisible-squiggles/compare/v0.4.0..v0.4.1) - 2026-08-03
+
+No functional changes. The extension behaves exactly as it did in 0.4.0.
+
+### 📝 Documentation
+
+- Document all six `invisibleSquiggles.*` settings, which were previously discoverable only through the Settings UI - ([#248](https://github.com/michen00/invisible-squiggles/pull/248))
+- Add instructions for binding a keyboard shortcut to **Toggle Squiggles**; the extension ships no default binding - ([#248](https://github.com/michen00/invisible-squiggles/pull/248))
+- Add [SECURITY.md](https://github.com/michen00/invisible-squiggles/blob/main/SECURITY.md), covering vulnerability reporting, what the extension can reach, and how to verify a release - ([#248](https://github.com/michen00/invisible-squiggles/pull/248))
+
+### 💚 Release pipeline
+
+- Releases now carry the `.vsix` as a release asset again - ([#243](https://github.com/michen00/invisible-squiggles/pull/243))
+- The two registries publish independently, so a failure at one no longer withholds the release from the other - ([#241](https://github.com/michen00/invisible-squiggles/pull/241))
+
 ## [0.4.0](https://github.com/michen00/invisible-squiggles/compare/v0.3.1..v0.4.0) - 2026-07-30
 
 ### ✨ Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "invisible-squiggles",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "invisible-squiggles",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "SEE LICENSE IN LICENSE",
       "devDependencies": {
         "@types/mocha": "^10.0.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "invisible-squiggles",
   "displayName": "invisible squiggles",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "publisher": "michen00",
   "description": "toggle the transparency of diagnostic squiggles for distraction-free coding",
   "author": {


### PR DESCRIPTION
Release prep for v0.4.1. **No functional change** — the extension behaves exactly as it did in 0.4.0.

## Why release at all

The README is also the VS Code Marketplace and Open VSX listing, and **a listing only refreshes when a version is published.** #248 documented all six settings and added keybinding instructions, but until something ships, neither listing shows them. That is the whole reason for this version.

## The hand-written changelog entry

`git-cliff` generates nothing for this range. Every commit since v0.4.0 is `ci`, `build`, or `docs`, and `cliff.toml` skips all three, so the automated output is a `## [0.4.1]` heading with nothing beneath it.

An empty heading reads as an oversight. The entry therefore states plainly that nothing user-facing changed, then lists what did:

- **Documentation** — the six `invisibleSquiggles.*` settings, previously discoverable only by browsing the Settings UI; keyboard-shortcut instructions, since the extension ships no default binding; and SECURITY.md.
- **Release pipeline** — releases carry the `.vsix` again (#243), and the two registries publish independently (#241).

## Verification

Run locally before proposing this, since a release branch that fails at tag time wastes a version number:

```
make check                 → 0   unit, parallel, integration, E2E, script tests, tsc --noEmit
make verify-reproducible   → 0   "builds under umask 022 and 077 are byte-identical"
                                 Packaged: invisible-squiggles-0.4.1.vsix (8 files, 25.67 KB)
```

The version bump touches `package.json` and exactly two lines of `package-lock.json` — the root `version` and `packages[""].version`. A third `"version": "0.4.0"` in that file belongs to `node_modules/asynckit` and is deliberately untouched.

`make install-vsix` (step 5 of the release checklist) was **not** run — it invokes `code --install-extension` against the maintainer's editor, which is not mine to change. Worth doing by hand before merging if you want the manual smoke test.

## What happens after this merges

This is the first release under the flow from #243, so the sequence is new:

```
git tag -a v0.4.1 -m v0.4.1 -s
make verify-tag VERSION=v0.4.1
git push --follow-tags        → CI drafts the release with the VSIX attached
                                nothing published to any registry yet
                              → inspect the draft: notes, and the artifact itself
make release VERSION=v0.4.1   → freezes it, opens the discussion,
                                publishes to both registries
```

The draft step is the part worth watching, since it has never run on a real tag. Its failure mode is benign — a draft is deletable, and nothing reaches a registry until the last command.

One note on the date: the changelog says `2026-08-03`. If the tag gets pushed on a later day, that line should be updated to match, the way v0.4.0's entry matches its tag date.
