### PR TITLE
ci: add prep-release and tag make targets

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -56,7 +56,8 @@ Make targets mirror these (`make help`). Use `make build-vsix` / `make install-v
 ## Commit & Release
 
 - Conventional Commits, imperative, ≤50 chars: `feat: add toggle`, `fix: restore colors`, etc.
-- Release sketch: update `CHANGELOG.md` + `package.json`, `make rebuild && make check`, `make install-vsix`, then tag/publish (`npx vsce publish`).
+- Release sketch: `make prep-release VERSION=vX.Y.Z`, write the changelog entry by hand, merge the release PR, then `make tag VERSION=vX.Y.Z` (drafts the release) and `make release VERSION=vX.Y.Z` (publishes it). See CONTRIBUTING.md.
+- Never publish by hand. A bare `npx vsce publish` or `ovsx publish` packages internally, skipping the timestamp pinning that makes the build reproducible, so it ships bytes the provenance attestation does not cover.
 
 ## Documentation Hygiene
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,25 +169,39 @@ Editing a merged PR's description is fine and worth doing when it turns out to b
 
 ## Creating a release
 
-1. Prepare a release branch: `git switch main && git pull && git switch -c release/vX.Y.Z`
-2. Update `CHANGELOG.md`:
-   - Run `make update-unreleased` to update the Unreleased section (this auto-commits).
-   - Make any additional edits (e.g., rename heading from "Unreleased" to the version).
-3. Update version in `package.json`.
-4. Build and test: `make rebuild && make check`
-5. Test locally: `make install-vsix`
-6. Commit remaining changes: `git commit -am "chore: release vX.Y.Z"`
-7. Push the branch and open a PR: `git push -u origin release/vX.Y.Z`
-8. Merge the PR into `main` (via GitHub).
-9. Get the latest main: `git switch main && git pull`
-10. Create a signed tag: `git tag -a vX.Y.Z -m vX.Y.Z -s`
-    - The `-s` is required. `tag.gpgsign` is not set globally, so a tag made without it
-      is unsigned and `make verify-tag` will fail on it. Confirm with
-      `make verify-tag VERSION=vX.Y.Z` before pushing.
-11. Push with tags: `git push --follow-tags`
-12. That push starts the `publish extension` workflow in **draft** mode: it builds one VSIX, proves it reproducible, attests it, and leaves a draft release carrying that exact file. Nothing reaches a registry on this path.
-13. Review the draft. The generated notes and the attested artifact are both sitting there to be looked at, and a draft can still be deleted — nothing is committed to yet. Edit the notes in the web UI if they need it.
-14. Publish it: `make release VERSION=vX.Y.Z`. **This is the irreversible step.** It freezes the release with its asset, starts the Announcements discussion, and fires the same workflow again, which ships that build to the VSCode Marketplace and Open VSX. Neither registry allows replacing a published version.
+1. Prepare the release branch: `make prep-release VERSION=vX.Y.Z`
+   - Branches from main, bumps the version in `package.json` and `package-lock.json`
+     via `npm version`, opens a dated changelog section, and runs `make check`.
+   - It stops before committing, because the next step is prose.
+2. Write the `vX.Y.Z` changelog entry. It starts empty and may stay empty on its own:
+   `cliff.toml` skips `ci`, `build`, `docs`, `test`, `refactor` and `chore`, so a
+   release made only of those generates no entries at all. Say so outright rather
+   than shipping a bare version heading.
+3. Optionally smoke-test the build: `make install-vsix`
+4. Commit and open a PR:
+
+   ```sh
+   git commit -am "chore: release vX.Y.Z"
+   git push -u origin release/vX.Y.Z
+   gh pr create
+   ```
+
+5. Merge the PR into `main` (via GitHub).
+6. Get the latest main: `git switch main && git pull`
+7. Tag it: `make tag VERSION=vX.Y.Z`
+   - Signs with SSH, verifies the signature against `.github/allowed_signers`, and
+     pushes that one tag. It refuses if the version disagrees with `package.json`,
+     if you are not on an up-to-date `main`, if the tree is dirty, or if the tag
+     already exists; and it deletes the local tag if verification fails, so an
+     unverifiable tag never reaches the remote.
+   - Use the target rather than tagging by hand. `tag.gpgsign` is deliberately unset
+     here, so a hand-typed `git tag -a` without `-s` produces an unsigned tag that
+     looks identical in `git tag -l`. `git push --follow-tags` is also wider than it
+     appears — it pushes any reachable annotated tag missing from the remote, not
+     just yours.
+8. That push starts the `publish extension` workflow in **draft** mode: it builds one VSIX, proves it reproducible, attests it, and leaves a draft release carrying that exact file. Nothing reaches a registry on this path.
+9. Review the draft. The generated notes and the attested artifact are both sitting there to be looked at, and a draft can still be deleted — nothing is committed to yet. Edit the notes in the web UI if they need it.
+10. Publish it: `make release VERSION=vX.Y.Z`. **This is the irreversible step.** It freezes the release with its asset, starts the Announcements discussion, and fires the same workflow again, which ships that build to the VSCode Marketplace and Open VSX. Neither registry allows replacing a published version.
 
 ### Publishing
 

--- a/Makefile
+++ b/Makefile
@@ -243,15 +243,20 @@ update-unreleased: ## Update the Unreleased section of CHANGELOG.md and commit
 # The two mechanical halves of cutting a release. Between them they replace the
 # steps that were hand-typed, and only those: deciding what the changelog says,
 # reviewing the draft, and publishing it stay manual on purpose.
+#
+# VERSION is quoted on the way through so the value reaches the script as one
+# argument whatever it contains. Unquoted, `VERSION="v1.0.0 x"` arrives as two
+# arguments and the script reports a wrong argument count instead of a malformed
+# version -- the guard still holds, but it names the wrong problem.
 .PHONY: prep-release
 prep-release: ## Branch, bump the version, open a changelog section, check (VERSION=vX.Y.Z)
 	@if [ -z "$(VERSION)" ]; then echo "Usage: make prep-release VERSION=vX.Y.Z"; exit 1; fi
-	@scripts/prep-release.sh $(VERSION)
+	@scripts/prep-release.sh "$(VERSION)"
 
 .PHONY: tag
 tag: ## Sign, verify, and push a release tag, drafting the release (VERSION=vX.Y.Z)
 	@if [ -z "$(VERSION)" ]; then echo "Usage: make tag VERSION=vX.Y.Z"; exit 1; fi
-	@SIGNERS_FILE=$(SIGNERS_FILE) scripts/release-tag.sh $(VERSION)
+	@SIGNERS_FILE="$(SIGNERS_FILE)" scripts/release-tag.sh "$(VERSION)"
 
 # Verifies a release tag against the committed public key in
 # .github/allowed_signers. The signed tag is the source-authenticity anchor;

--- a/Makefile
+++ b/Makefile
@@ -240,6 +240,19 @@ verify-reproducible: ## Verify two builds produce identical bytes (assumes depen
 update-unreleased: ## Update the Unreleased section of CHANGELOG.md and commit
 	@scripts/update-unreleased.sh --commit
 
+# The two mechanical halves of cutting a release. Between them they replace the
+# steps that were hand-typed, and only those: deciding what the changelog says,
+# reviewing the draft, and publishing it stay manual on purpose.
+.PHONY: prep-release
+prep-release: ## Branch, bump the version, open a changelog section, check (VERSION=vX.Y.Z)
+	@if [ -z "$(VERSION)" ]; then echo "Usage: make prep-release VERSION=vX.Y.Z"; exit 1; fi
+	@scripts/prep-release.sh $(VERSION)
+
+.PHONY: tag
+tag: ## Sign, verify, and push a release tag, drafting the release (VERSION=vX.Y.Z)
+	@if [ -z "$(VERSION)" ]; then echo "Usage: make tag VERSION=vX.Y.Z"; exit 1; fi
+	@SIGNERS_FILE=$(SIGNERS_FILE) scripts/release-tag.sh $(VERSION)
+
 # Verifies a release tag against the committed public key in
 # .github/allowed_signers. The signed tag is the source-authenticity anchor;
 # built artifacts carry keyless provenance instead (see CONTRIBUTING.md).

--- a/Makefile
+++ b/Makefile
@@ -282,7 +282,7 @@ release: ## Publish the drafted release (VERSION=vX.Y.Z)
 	@gh release view $(VERSION) --json isDraft --jq .isDraft 2>/dev/null | grep -qx true || { \
 		echo "Error: no draft release for $(VERSION)."; \
 		echo "Push the tag and let the publish workflow draft it:"; \
-		echo "  git push --follow-tags"; \
+		echo "  git push origin refs/tags/$(VERSION)"; \
 		echo "Already published? Then it is done, or retry a registry with:"; \
 		echo "  gh workflow run publish.yml -f tag=$(VERSION) -f targets=both"; \
 		exit 1; }

--- a/scripts/prep-release.sh
+++ b/scripts/prep-release.sh
@@ -95,6 +95,27 @@ if [ "$current" = "$BARE" ]; then
     "Pick the next version, or check whether this release is already prepared."
 fi
 
+# Ordering, not just inequality. `npm version` rewrites both manifests to whatever it
+# is given, downward included and without complaint, so preparing v0.3.2 from a 0.4.1
+# main would produce a branch that looks like a release and declares a version the
+# project already moved past. Merged and tagged, that either collides with a
+# published version or silently ships a regression in the version number.
+#
+# Compared numerically in node rather than with `sort -V`, which BSD sort on macOS
+# does not implement.
+if ! node -e '
+  const parse = (v) => v.split(".").map(Number);
+  const [next, prev] = [parse(process.argv[1]), parse(process.argv[2])];
+  for (let i = 0; i < 3; i++) {
+    if (next[i] !== prev[i]) process.exit(next[i] > prev[i] ? 0 : 1);
+  }
+  process.exit(1);
+' "$BARE" "$current"; then
+  die "$BARE is not ahead of the current version ($current)." \
+    "Releases only move forward. Both registries refuse to replace a version" \
+    "that has been published, so a number cannot be walked back afterwards."
+fi
+
 if git rev-parse --verify "refs/tags/$VERSION" > /dev/null 2>&1 ||
   git ls-remote --exit-code --tags origin "refs/tags/$VERSION" > /dev/null 2>&1; then
   die "tag $VERSION already exists." "That version has been cut. Release forward instead."

--- a/scripts/prep-release.sh
+++ b/scripts/prep-release.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+
+# Prepare a release branch: bump the version, open the changelog section, verify.
+#
+# Every step here was previously hand-typed, and each has a way of going quietly
+# wrong that this script removes:
+#
+#   - The version lives in package.json *and* twice in package-lock.json, where a
+#     third identical "version": "x.y.z" belongs to an unrelated dependency. Editing
+#     the lockfile by hand means hitting two of three matching lines. `npm version`
+#     updates exactly the right ones.
+#   - The changelog heading needs a compare link and today's date. A date typed by
+#     hand is a date typed on whichever day the branch was prepared, which is not
+#     necessarily the day the tag gets cut.
+#
+# Deliberately stops before committing. The changelog *body* is prose, and for a
+# release whose commits are all ci/build/docs, git-cliff generates nothing at all --
+# cliff.toml skips those types. So the section this opens is often empty, and an
+# empty section needs a human sentence rather than a default one.
+
+set -euo pipefail
+
+SCRIPT_NAME=$(basename "$0")
+CHANGELOG="CHANGELOG.md"
+REPO_URL="https://github.com/michen00/invisible-squiggles"
+
+usage() {
+  cat << EOF
+Usage: $SCRIPT_NAME <version>
+
+Create a release branch, bump the version in package.json and
+package-lock.json, open a dated changelog section, and run the full
+check suite. Stops before committing so the changelog entry can be
+written by hand.
+
+Arguments:
+  <version>   Release version of the form vX.Y.Z (e.g. v0.4.2)
+
+Example:
+  $SCRIPT_NAME v0.4.2
+EOF
+  exit "${1:-0}"
+}
+
+die() {
+  echo "Error: $1" >&2
+  shift
+  for line in "$@"; do
+    echo "  $line" >&2
+  done
+  exit 1
+}
+
+if [ "$#" -ne 1 ]; then
+  usage 1
+fi
+
+case "$1" in
+  -h | --help) usage 0 ;;
+esac
+
+VERSION="$1"
+
+case "$VERSION" in
+  v[0-9]*.[0-9]*.[0-9]*) ;;
+  *) die "version must look like vX.Y.Z, got '$VERSION'." ;;
+esac
+
+BARE="${VERSION#v}"
+
+branch=$(git branch --show-current)
+if [ "$branch" != "main" ]; then
+  die "on '$branch', not main." \
+    "A release branch should start from main so the release contains only" \
+    "what main contains."
+fi
+
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  die "the working tree is dirty." \
+    "Commit or stash first; this script is about to edit tracked files."
+fi
+
+git fetch origin main --quiet
+if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]; then
+  die "main and origin/main point at different commits." \
+    "Run 'git pull' so the release branch starts from the real main."
+fi
+
+current="$(node -p "require('./package.json').version")"
+if [ "$current" = "$BARE" ]; then
+  die "package.json already declares $BARE." \
+    "Pick the next version, or check whether this release is already prepared."
+fi
+
+if git rev-parse --verify "refs/tags/$VERSION" > /dev/null 2>&1 ||
+  git ls-remote --exit-code --tags origin "refs/tags/$VERSION" > /dev/null 2>&1; then
+  die "tag $VERSION already exists." "That version has been cut. Release forward instead."
+fi
+
+if ! grep -q '^## \[Unreleased\]' "$CHANGELOG"; then
+  die "no '## [Unreleased]' heading in $CHANGELOG." \
+    "Run 'make update-unreleased' first, which creates it."
+fi
+
+if grep -q "^## \[$BARE\]" "$CHANGELOG"; then
+  die "$CHANGELOG already has a section for $BARE."
+fi
+
+git switch -c "release/$VERSION"
+
+# Updates package.json and both of the lockfile's own version fields, leaving
+# dependency versions untouched. --no-git-tag-version because tagging is a separate,
+# later step -- see scripts/release-tag.sh.
+npm version "$BARE" --no-git-tag-version > /dev/null
+echo "Bumped $current -> $BARE in package.json and package-lock.json."
+
+# Today, resolved now rather than typed. If the tag is cut on a later day this line
+# needs updating, which is the one thing about the date that cannot be automated
+# from here.
+today=$(date +%Y-%m-%d)
+heading="## [$BARE]($REPO_URL/compare/v$current..$VERSION) - $today"
+
+# Inserted immediately after the Unreleased heading, which stays in place to collect
+# the next cycle's entries.
+awk -v heading="$heading" '
+  /^## \[Unreleased\]$/ && !done { print; print ""; print heading; done = 1; next }
+  { print }
+' "$CHANGELOG" > "$CHANGELOG.tmp" && mv "$CHANGELOG.tmp" "$CHANGELOG"
+echo "Opened changelog section: $heading"
+
+echo
+echo "Running the full check suite..."
+make check
+
+cat << EOF
+
+Prepared release/$VERSION. Nothing has been committed.
+
+Still to do by hand:
+  1. Write the $BARE changelog entry. It is empty right now, and it may stay
+     empty automatically -- cliff.toml skips ci, build, docs, test, refactor
+     and chore, so a release made only of those generates no entries. Say so
+     outright rather than shipping a bare heading.
+  2. Optionally smoke-test the build:  make install-vsix
+  3. Commit and open the PR:
+       git commit -am "chore: release $VERSION"
+       git push -u origin release/$VERSION
+       gh pr create
+
+After that PR merges:
+       make tag VERSION=$VERSION      # drafts the release, publishes nothing
+       make release VERSION=$VERSION  # publishes to both registries
+EOF

--- a/scripts/prep-release.sh
+++ b/scripts/prep-release.sh
@@ -61,10 +61,13 @@ esac
 
 VERSION="$1"
 
-case "$VERSION" in
-  v[0-9]*.[0-9]*.[0-9]*) ;;
-  *) die "version must look like vX.Y.Z, got '$VERSION'." ;;
-esac
+# Anchored regex rather than a glob. `v[0-9]*.[0-9]*.[0-9]*` reads as if it means
+# digits, but glob `*` is any-characters, so it admits v1abc.2.3 -- which would pass
+# here and then reach `npm version 1abc.2.3`, failing with an error about semver
+# rather than about the argument. Matches the publish workflow's own tag filter.
+if [[ ! $VERSION =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  die "version must look like vX.Y.Z, got '$VERSION'."
+fi
 
 BARE="${VERSION#v}"
 

--- a/scripts/prep-release.sh
+++ b/scripts/prep-release.sh
@@ -143,9 +143,26 @@ git switch -c "release/$VERSION"
 npm version "$BARE" --no-git-tag-version > /dev/null
 echo "Bumped $current -> $BARE in package.json and package-lock.json."
 
-# Today, resolved now rather than typed. If the tag is cut on a later day this line
-# needs updating, which is the one thing about the date that cannot be automated
-# from here.
+# Regenerate the Unreleased section before promoting it. The heading insertion below
+# turns whatever is currently under `## [Unreleased]` into the new version's entries,
+# so a section last generated before the most recent feat and fix commits would
+# promote an incomplete list -- and every check here would still pass, because
+# nothing else reads the changelog. The old documented flow ran this as its own step;
+# dropping it silently is what made the omission possible.
+#
+# Without --commit: this script leaves everything staged-but-uncommitted for review.
+echo "Regenerating the Unreleased section..."
+scripts/update-unreleased.sh
+
+# Re-checked, because the updater rewrites the section it is named after.
+if ! grep -q '^## \[Unreleased\]$' "$CHANGELOG"; then
+  die "the Unreleased heading did not survive regeneration." \
+    "Inspect $CHANGELOG and scripts/update-unreleased.sh."
+fi
+
+# Today, resolved now rather than typed. The tag may still be cut on a later day, so
+# scripts/release-tag.sh re-checks this date against the day of the tag and refuses
+# if they disagree.
 today=$(date +%Y-%m-%d)
 heading="## [$BARE]($REPO_URL/compare/v$current..$VERSION) - $today"
 

--- a/scripts/prep-release.sh
+++ b/scripts/prep-release.sh
@@ -100,9 +100,14 @@ if git rev-parse --verify "refs/tags/$VERSION" > /dev/null 2>&1 ||
   die "tag $VERSION already exists." "That version has been cut. Release forward instead."
 fi
 
-if ! grep -q '^## \[Unreleased\]' "$CHANGELOG"; then
+# Anchored to match the awk below exactly. Without the `$`, a heading carrying
+# trailing text passed this check and then matched nothing during insertion, and the
+# script went on to report success.
+if ! grep -q '^## \[Unreleased\]$' "$CHANGELOG"; then
   die "no '## [Unreleased]' heading in $CHANGELOG." \
-    "Run 'make update-unreleased' first, which creates it."
+    "Run 'make update-unreleased' first, which creates it." \
+    "A heading with trailing text does not count: the insertion below matches" \
+    "the line exactly, so it has to be exactly that."
 fi
 
 if grep -q "^## \[$BARE\]" "$CHANGELOG"; then
@@ -129,6 +134,16 @@ awk -v heading="$heading" '
   /^## \[Unreleased\]$/ && !done { print; print ""; print heading; done = 1; next }
   { print }
 ' "$CHANGELOG" > "$CHANGELOG.tmp" && mv "$CHANGELOG.tmp" "$CHANGELOG"
+
+# Checked rather than announced. The awk above silently makes no change if its
+# pattern does not match, and reporting an insertion that did not happen is worse
+# than failing: the next steps are a commit and a tag, and the missing section would
+# surface as a released version with no changelog entry at all.
+if ! grep -qF "$heading" "$CHANGELOG"; then
+  die "failed to insert the changelog heading." \
+    "Expected to add: $heading" \
+    "Check the '## [Unreleased]' heading in $CHANGELOG."
+fi
 echo "Opened changelog section: $heading"
 
 echo

--- a/scripts/release-tag.sh
+++ b/scripts/release-tag.sh
@@ -62,10 +62,13 @@ esac
 
 VERSION="$1"
 
-case "$VERSION" in
-  v[0-9]*.[0-9]*.[0-9]*) ;;
-  *) die "version must look like vX.Y.Z, got '$VERSION'." ;;
-esac
+# Anchored regex rather than a glob. `v[0-9]*.[0-9]*.[0-9]*` reads as if it means
+# digits, but glob `*` is any-characters, so it admits v1abc.2.3 -- which passes here
+# and then fails somewhere less obvious, in whichever tool touches it first. This
+# matches the publish workflow's own tag filter, where `+` really is a quantifier.
+if [[ ! $VERSION =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  die "version must look like vX.Y.Z, got '$VERSION'."
+fi
 
 # Checked here as well as in the publish workflow. The workflow's check is the one
 # that matters, but reaching it costs a queue wait and a dependency install first.

--- a/scripts/release-tag.sh
+++ b/scripts/release-tag.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+
+# Create, verify, and push a signed release tag.
+#
+# Exists because the three commands it replaces were hand-typed, and one of them
+# carries a flag that must not be forgotten. `tag.gpgsign` is deliberately unset in
+# this project, so `git tag -a vX.Y.Z -m vX.Y.Z` without `-s` produces an unsigned
+# tag that looks identical in `git tag -l` and is caught only by a separate
+# verify-tag step that is equally easy to skip. Here the flag cannot be forgotten
+# and the verification is not optional.
+#
+# The preflight checks below all guard the same class of mistake: tagging a commit
+# that is not the one about to be released. Each of them would otherwise surface as
+# a failed or wrong CI run several minutes later.
+#
+# Pushing is part of this script because a tag that exists only locally does
+# nothing -- pushing it is what makes CI draft the release. That is reversible: the
+# draft build publishes to no registry, and both the draft and the tag can be
+# deleted.
+
+set -euo pipefail
+
+SCRIPT_NAME=$(basename "$0")
+SIGNERS_FILE="${SIGNERS_FILE:-.github/allowed_signers}"
+
+usage() {
+  cat << EOF
+Usage: $SCRIPT_NAME <version>
+
+Create a signed annotated tag, verify its signature, and push it.
+Pushing the tag makes CI draft the release with the VSIX attached.
+Nothing is published to any registry.
+
+Arguments:
+  <version>   Release tag of the form vX.Y.Z (e.g. v0.4.2)
+
+Environment:
+  SIGNERS_FILE   Allowed-signers file (default: .github/allowed_signers)
+
+Example:
+  $SCRIPT_NAME v0.4.2
+EOF
+  exit "${1:-0}"
+}
+
+die() {
+  echo "Error: $1" >&2
+  shift
+  for line in "$@"; do
+    echo "  $line" >&2
+  done
+  exit 1
+}
+
+if [ "$#" -ne 1 ]; then
+  usage 1
+fi
+
+case "$1" in
+  -h | --help) usage 0 ;;
+esac
+
+VERSION="$1"
+
+case "$VERSION" in
+  v[0-9]*.[0-9]*.[0-9]*) ;;
+  *) die "version must look like vX.Y.Z, got '$VERSION'." ;;
+esac
+
+# Checked here as well as in the publish workflow. The workflow's check is the one
+# that matters, but reaching it costs a queue wait and a dependency install first.
+manifest="v$(node -p "require('./package.json').version")"
+if [ "$manifest" != "$VERSION" ]; then
+  die "$VERSION does not match package.json ($manifest)." \
+    "Bump the manifest first, or tag the version it already declares."
+fi
+
+branch=$(git branch --show-current)
+if [ "$branch" != "main" ]; then
+  die "on '$branch', not main." \
+    "A release tag names a commit on main. Tagging elsewhere would ship" \
+    "whatever that branch contains, and the tag would outlive the branch."
+fi
+
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  die "the working tree is dirty." \
+    "The tag would name HEAD, not what you are looking at."
+fi
+
+git fetch origin main --quiet
+if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]; then
+  die "main and origin/main point at different commits." \
+    "CI checks out the tag from the remote, so tagging a commit that is not" \
+    "on origin/main would build something other than what you tested."
+fi
+
+if git rev-parse --verify "refs/tags/$VERSION" > /dev/null 2>&1; then
+  die "tag $VERSION already exists locally." \
+    "Delete it first if you meant to re-cut it: git tag -d $VERSION"
+fi
+
+if git ls-remote --exit-code --tags origin "refs/tags/$VERSION" > /dev/null 2>&1; then
+  die "tag $VERSION already exists on origin." \
+    "That version has been cut. Release forward instead."
+fi
+
+# -s rather than relying on configuration, which is the entire point of this script.
+git tag -a "$VERSION" -m "$VERSION" -s
+echo "Created signed tag $VERSION."
+
+# Verified rather than assumed: a signing key that has gone missing or expired fails
+# here, while the tag still exists only locally and can simply be deleted.
+if ! git -c "gpg.ssh.allowedSignersFile=$SIGNERS_FILE" verify-tag "$VERSION"; then
+  git tag -d "$VERSION"
+  die "signature verification failed; the local tag has been deleted." \
+    "Check that your signing key is present and listed in $SIGNERS_FILE."
+fi
+
+git push --follow-tags
+echo
+echo "Pushed $VERSION. CI is now drafting the release with the VSIX attached."
+echo "Nothing has been published. Review the draft, then publish it:"
+echo "  make release VERSION=$VERSION"

--- a/scripts/release-tag.sh
+++ b/scripts/release-tag.sh
@@ -129,7 +129,17 @@ if ! git -c gpg.format=ssh -c "gpg.ssh.allowedSignersFile=$SIGNERS_FILE" \
     "Check that your signing key is present and listed in $SIGNERS_FILE."
 fi
 
-git push --follow-tags
+# An explicit refspec rather than --follow-tags, which pushes more than it looks
+# like. Per git-push(1) it also pushes "annotated tags in refs/tags that are missing
+# from the remote but are pointing at commit-ish that are reachable from the refs
+# being pushed" -- so any stray local annotated tag would ride along having passed
+# none of the checks above, and could start the draft workflow for a version nobody
+# asked to release. Everything above validates exactly one tag; this pushes exactly
+# that one.
+#
+# main needs no push of its own: the check above already required HEAD and
+# origin/main to be the same commit.
+git push origin "refs/tags/$VERSION"
 echo
 echo "Pushed $VERSION. CI is now drafting the release with the VSIX attached."
 echo "Nothing has been published. Review the draft, then publish it:"

--- a/scripts/release-tag.sh
+++ b/scripts/release-tag.sh
@@ -78,6 +78,30 @@ if [ "$manifest" != "$VERSION" ]; then
     "Bump the manifest first, or tag the version it already declares."
 fi
 
+# The changelog's date for this version is written when the release branch is
+# prepared, which can be days before the tag, and it is what users read as the release
+# date. v0.4.1 was prepared on one day and tagged the next, shipping a date that had to
+# be corrected twice. Checked here because this is the last moment before the tag
+# exists, and because nothing downstream looks at the changelog at all.
+BARE="${VERSION#v}"
+CHANGELOG="CHANGELOG.md"
+changelog_heading=$(grep -m1 -F "## [$BARE](" "$CHANGELOG" || true)
+if [ -z "$changelog_heading" ]; then
+  die "$CHANGELOG has no section for $BARE." \
+    "The release commit should have added one, so check that this tag is on the" \
+    "commit you meant to release."
+fi
+today=$(date +%Y-%m-%d)
+case "$changelog_heading" in
+  *" - $today") ;;
+  *)
+    die "the $BARE changelog heading is not dated today ($today)." \
+      "  $changelog_heading" \
+      "That date is the release date as far as readers are concerned. Correct the" \
+      "line on main before tagging."
+    ;;
+esac
+
 branch=$(git branch --show-current)
 if [ "$branch" != "main" ]; then
   die "on '$branch', not main." \

--- a/scripts/release-tag.sh
+++ b/scripts/release-tag.sh
@@ -108,12 +108,22 @@ if git ls-remote --exit-code --tags origin "refs/tags/$VERSION" > /dev/null 2>&1
 fi
 
 # -s rather than relying on configuration, which is the entire point of this script.
-git tag -a "$VERSION" -m "$VERSION" -s
-echo "Created signed tag $VERSION."
+#
+# gpg.format is pinned to ssh for the same reason, and it is the more important half.
+# `-s` signs with whatever format happens to be configured, and git's default is
+# openpgp -- so on a machine with a GPG key set up, `-s` produces a tag that this
+# project's documented verification route cannot check, because that route is an SSH
+# allowed-signers file. Worse, the check below would not catch it: verification
+# format follows the signature, so a GPG-signed tag gets GPG-verified and passes
+# wherever the local keyring trusts the key. The tag would push, and only a third
+# party following SECURITY.md would discover it is unverifiable to them.
+git -c gpg.format=ssh tag -a "$VERSION" -m "$VERSION" -s
+echo "Created SSH-signed tag $VERSION."
 
-# Verified rather than assumed: a signing key that has gone missing or expired fails
-# here, while the tag still exists only locally and can simply be deleted.
-if ! git -c "gpg.ssh.allowedSignersFile=$SIGNERS_FILE" verify-tag "$VERSION"; then
+# Verified rather than assumed: a signing key that has gone missing, or one absent
+# from the allowed-signers file, fails here while the tag exists only locally.
+if ! git -c gpg.format=ssh -c "gpg.ssh.allowedSignersFile=$SIGNERS_FILE" \
+  verify-tag "$VERSION"; then
   git tag -d "$VERSION"
   die "signature verification failed; the local tag has been deleted." \
     "Check that your signing key is present and listed in $SIGNERS_FILE."


### PR DESCRIPTION
Cutting v0.4.1 took fifteen steps. Two of them were decisions — reviewing the draft, and publishing it. The other thirteen were typed by hand, and the clerical ones went wrong repeatedly on the way.

This adds the two targets that absorb the mechanical half. The judgement half is untouched on purpose.

```
make prep-release VERSION=vX.Y.Z    branch, bump, open a dated changelog section, check
make tag VERSION=vX.Y.Z             sign, verify, push -> drafts the release
```

## Each replaces a specific way of being quietly wrong

**The lockfile.** The version lives in `package.json` and twice in `package-lock.json` — where a third identical `"version": "0.4.0"` belongs to `node_modules/asynckit`. Doing it by hand means hitting two of three matching lines and skipping the one that looks the same. `npm version --no-git-tag-version` hits exactly the right ones.

**The date.** The changelog heading needs a compare link and a date. Typed by hand it is the date the branch was prepared, not the date the tag is cut — for v0.4.1 those differed, and the line had to be corrected twice. `prep-release` resolves it at run time.

**`-s` on the tag.** The sharpest of the three. `tag.gpgsign` is unset in this project deliberately, so a tag made without the flag is unsigned, looks identical in `git tag -l`, and is caught only by a separate verify step that is exactly as easy to skip as the flag was to forget — a footgun CONTRIBUTING.md has to warn about in prose. Now the flag cannot be forgotten, verification is not optional, and **a failed verification deletes the local tag** rather than leaving an unsigned one sitting there ready to push.

## The preflight checks

All of them guard one mistake — tagging a commit that is not the one being released — and each would otherwise surface as a failed or wrong CI run minutes later:

| Check | Why |
| --- | --- |
| version shape `vX.Y.Z` | the workflow's tag filter and validator both require it |
| matches `package.json` | the workflow checks this too, but reaching it costs a queue wait and an install |
| on `main` | a release tag names a commit on main; tagging elsewhere ships that branch |
| clean tree | the tag names HEAD, not what you are looking at |
| `main` == `origin/main` | CI checks the tag out from the remote, so an unsynced local main builds something else |
| tag not already cut, locally or on origin | both registries refuse to replace a published version |

## What stays manual, deliberately

`prep-release` **stops before committing.** The changelog body is prose, and for a release made only of `ci`, `build`, and `docs` commits, git-cliff generates nothing at all — `cliff.toml` skips those types. So the section it opens is frequently empty, and an empty section needs a human sentence rather than a default one. It prints that as the first outstanding item.

Reviewing the draft and running `make release` remain two deliberate commands. The point of this PR is to stop spending attention on typing tags and dates so there is more of it left for the two steps where attention pays.

## Verification

Guards were exercised rather than reasoned about. Every failing path returns exit 1 and does nothing:

```
release-tag.sh v0.4.1        (from a feature branch)  → refuses: not on main
release-tag.sh v0.4.2        (manifest says 0.4.1)    → refuses: version mismatch
release-tag.sh nightly                                → refuses: bad shape
release-tag.sh              (no args)                 → usage
prep-release.sh 1.2.3                                 → refuses: bad shape
prep-release.sh v0.4.1       (already that version)    → refuses: already prepared
```

The main-only guards needed the scripts present on a main checkout, so they were run from one and then removed; main's tree was left clean, with no branch or tag created.

**The sync guard proved itself during that run.** It refused with *"main and origin/main point at different commits"* — which turned out to be true rather than a false positive: #250 and #251 had merged while this branch was being written, leaving the local main stale at 53a754a against 17f54b0. That is precisely the state it exists to catch, and it caught it unprompted.

`shellcheck` and `shfmt` cover both scripts via pre-commit, which is why the logic lives in `scripts/` rather than in Makefile recipes.

## Known limitation

`prep-release`'s happy path cannot be exercised without actually preparing a release, so it gets its first real run at v0.4.2. Its failure mode is a local branch and two edited files, with nothing pushed and nothing committed — `git switch main && git branch -D release/vX.Y.Z` undoes it entirely.
