### PR TITLE
ci: check pr titles against cliff.toml

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -50,7 +50,16 @@ jobs:
           # user-controlled text and has no business being expanded by the shell.
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          gh pr view "${PR_NUMBER}" --json files --jq '.files[].path' > changed.txt
+          # Not `gh pr view --json files`: that asks for the first 100 files and says
+          # nothing about the rest, so on a larger pull request the only src/ change
+          # could sit past the cut and a correct feat:/fix: title would be rejected.
+          # Measured against a 115-file pull request: --json files returned 100 paths,
+          # the call below returned all 115. Its own ceiling is the REST endpoint's
+          # 3000 files, far past anything this repository will produce. A failure here
+          # aborts the step rather than handing the checker a short list, because the
+          # default shell for `run` is `bash -e`.
+          gh api --paginate "repos/${GH_REPO}/pulls/${PR_NUMBER}/files?per_page=100" \
+            --jq '.[].filename' > changed.txt
           echo "Changed files:"
           sed 's/^/  /' changed.txt
           echo

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -58,8 +58,11 @@ jobs:
           # 3000 files, far past anything this repository will produce. A failure here
           # aborts the step rather than handing the checker a short list, because the
           # default shell for `run` is `bash -e`.
+          # Renames emit both paths, matching the idiom bot-automerge.yml already uses:
+          # `filename` is the path after the move, so a file renamed out of src/ would
+          # otherwise look like nothing user-facing changed and reject a true feat:.
           gh api --paginate "repos/${GH_REPO}/pulls/${PR_NUMBER}/files?per_page=100" \
-            --jq '.[].filename' > changed.txt
+            --jq '.[] | .filename, (.previous_filename // empty)' > changed.txt
           echo "Changed files:"
           sed 's/^/  /' changed.txt
           echo

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,57 @@
+---
+name: PR title
+# The pull request title is unguarded and load-bearing. This repository squash-merges,
+# and GitHub uses the title as the squash subject whenever a branch carries more than
+# one commit -- so the title, not any commit message, is what git-cliff reads when it
+# builds CHANGELOG.md and the marketplace changelog tab. gitlint runs on local commit
+# messages and never sees it.
+#
+# `types` has to include `edited`, because retitling is the fix this check asks for and
+# a check that does not re-run on a retitle cannot confirm it. That is also why this
+# lives in its own workflow rather than as a job in ci.yml: adding `edited` there would
+# re-run the entire test matrix every time somebody touched a title or description.
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, edited, synchronize, reopened]
+
+concurrency:
+  # Superseded titles are not worth checking; the latest edit is the one that matters.
+  group: pr-title-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  changelog-visibility:
+    name: Changelog visibility
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # cliff.toml and the checker are read from the PR head rather than from main, so
+      # a branch that changes which commit types reach the changelog is judged by its
+      # own rules. The trade is that a branch could also neuter the check by editing
+      # either file -- acceptable here, because this guards labelling quality rather
+      # than anything a determined author should be prevented from changing, and the
+      # edit would be sitting in the diff. `pull_request` rather than
+      # `pull_request_target`, so the token stays read-only and no secrets are exposed
+      # to branch code.
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Check the title against cliff.toml
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          # Via env rather than interpolated into the script: a title is arbitrary
+          # user-controlled text and has no business being expanded by the shell.
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          gh pr view "${PR_NUMBER}" --json files --jq '.files[].path' > changed.txt
+          echo "Changed files:"
+          sed 's/^/  /' changed.txt
+          echo
+          node scripts/check-pr-title.mjs "${PR_TITLE}" < changed.txt

--- a/.github/workflows/test-check-pr-title.yml
+++ b/.github/workflows/test-check-pr-title.yml
@@ -1,0 +1,43 @@
+---
+name: Test check-pr-title.mjs
+
+# cliff.toml is in the path filter because the checker reads it and asserts what it
+# finds there. A change to which commit types reach the changelog is exactly the change
+# that makes the checker's expectations stale, and the test is what says so.
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/test-check-pr-title.yml
+      - cliff.toml
+      - scripts/check-pr-title.mjs
+      - scripts/test-check-pr-title.sh
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/test-check-pr-title.yml
+      - cliff.toml
+      - scripts/check-pr-title.mjs
+      - scripts/test-check-pr-title.sh
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test-check-pr-title:
+    name: Test check-pr-title.mjs (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      # The test edits cliff.toml to prove the checker refuses a config it cannot
+      # read, and restores it on exit. Both runners get exercised because that
+      # editing uses sed, whose in-place behaviour differs between GNU and BSD --
+      # the test avoids `-i` for that reason, and this matrix is what keeps it honest.
+      - name: Test check-pr-title.mjs
+        run: |
+          scripts/test-check-pr-title.sh

--- a/Makefile
+++ b/Makefile
@@ -308,7 +308,8 @@ test: install ## Run tests
     npm run pretest; \
     npm run test; \
     scripts/test-prepare-readme.sh; \
-    scripts/test-normalize-vsix.sh
+    scripts/test-normalize-vsix.sh; \
+    scripts/test-check-pr-title.sh
 
 .PHONY: lint
 lint: install ## Run linters

--- a/scripts/check-pr-title.mjs
+++ b/scripts/check-pr-title.mjs
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+
+// Fail a pull request whose title would put a meaningless entry in the user-facing
+// changelog.
+//
+// The title matters more than it looks. This repository squash-merges, and when a
+// branch carries more than one commit GitHub uses the *pull request title* as the
+// squash subject. That subject is what git-cliff reads. So the title -- a field no
+// hook or linter currently touches -- decides what users see in CHANGELOG.md and in
+// the marketplace changelog tab, while gitlint only ever sees local commit messages.
+//
+// Two ways that goes wrong, both of which have happened here:
+//
+//   - A change with no user-facing effect titled `feat:` or `fix:`. Release tooling
+//     and CI work landed as "feat: draft releases so they carry the vsix" and
+//     "feat: add prep-release and tag make targets"; both would have appeared under
+//     "Features" for readers who cannot see a Makefile target, and both were caught
+//     by accident while looking at something else.
+//   - A title that is not conventional at all. cliff.toml ends with a catch-all
+//     `^.*` parser that is *not* skipped, so an unrecognised prefix does not fall out
+//     of the changelog -- it lands in "Other".
+//
+// Derived from cliff.toml rather than from a hardcoded list of types, so that
+// changing which types are skipped changes this check too. The parse is asserted
+// against known cases below; a cliff.toml this cannot read fails the run instead of
+// passing it.
+//
+// Usage:
+//   node scripts/check-pr-title.mjs "<pr title>" < changed-files.txt
+//
+// Exit codes: 0 pass, 1 the title needs changing, 2 this script could not do its job.
+
+import { readFileSync } from 'node:fs';
+
+const CLIFF = 'cliff.toml';
+const CATCH_ALL = '^.*';
+
+/**
+ * Paths whose contents can change what a user of the extension experiences.
+ *
+ * Deliberately narrow: `src/` is the extension, and `package.json` carries the
+ * contributed commands, settings and engine range. Everything else in the repository
+ * -- workflows, scripts, the Makefile, docs, configuration -- can be rewritten
+ * wholesale without altering the installed extension's behaviour, which is exactly
+ * why a `feat:` covering only those files is a mislabel.
+ *
+ * `src/test/` is excluded: tests are `test:` in this convention, and cliff skips it.
+ */
+function isUserFacing(path) {
+  if (path === 'package.json') return true;
+  return path.startsWith('src/') && !path.startsWith('src/test/');
+}
+
+/**
+ * Pull `commit_parsers` out of cliff.toml.
+ *
+ * A targeted line scan rather than a TOML library, because Node ships no TOML parser
+ * and adding a dependency to read one array is a poor trade. The entries are one per
+ * line and uniform. Anything that does not look like an entry is ignored, and the
+ * assertions in `selfCheck` decide whether what came back is trustworthy.
+ */
+function parseCommitParsers(toml) {
+  const start = toml.indexOf('commit_parsers = [');
+  if (start === -1) return [];
+  const end = toml.indexOf('\n]', start);
+  if (end === -1) return [];
+  const block = toml.slice(start, end);
+
+  const parsers = [];
+  for (const line of block.split('\n')) {
+    const match = /^\s*\{\s*message\s*=\s*"((?:[^"\\]|\\.)*)"(.*)$/.exec(line);
+    if (!match) continue;
+    parsers.push({
+      // TOML basic strings process backslash escapes, so `"^\\d+"` in the file is the
+      // regex `^\d+`. Only the doubled backslash appears in this config.
+      message: match[1].replace(/\\\\/g, '\\'),
+      skip: /\bskip\s*=\s*true\b/.test(match[2]),
+    });
+  }
+  return parsers;
+}
+
+/** Classify a subject the way git-cliff does: first matching parser wins. */
+function classify(parsers, subject) {
+  for (const parser of parsers) {
+    let re;
+    try {
+      re = new RegExp(parser.message);
+    } catch {
+      continue;
+    }
+    if (re.test(subject)) return parser;
+  }
+  return null;
+}
+
+/**
+ * Refuse to run on a cliff.toml this script has misread.
+ *
+ * Without this, a reformatted config would yield zero parsers, every title would
+ * classify as "not in the changelog", and the check would pass everything while
+ * appearing to work -- the failure mode it exists to prevent, applied to itself.
+ */
+function selfCheck(parsers) {
+  const problems = [];
+  if (parsers.length < 10) {
+    problems.push(`only ${parsers.length} parsers found in ${CLIFF}`);
+  }
+  const expectations = [
+    ['feat: add a thing', false, 'a feature must reach the changelog'],
+    ['fix: repair a thing', false, 'a fix must reach the changelog'],
+    ['ci: adjust a workflow', true, 'ci must be skipped'],
+    ['docs: reword a page', true, 'docs must be skipped'],
+    ['build(deps): bump a dep', true, 'dependency bumps must be skipped'],
+    ['chore(deps-dev): bump a dep', true, 'dev dependency bumps must be skipped'],
+  ];
+  for (const [subject, wantSkip, why] of expectations) {
+    const parser = classify(parsers, subject);
+    if (!parser) {
+      problems.push(`"${subject}" matched no parser at all`);
+    } else if (parser.skip !== wantSkip) {
+      problems.push(`"${subject}" was ${parser.skip ? 'skipped' : 'kept'} -- ${why}`);
+    }
+  }
+  return problems;
+}
+
+const title = process.argv[2];
+if (!title) {
+  console.error(`Usage: ${process.argv[1]} "<pr title>" < changed-files.txt`);
+  process.exit(2);
+}
+
+const changed = readFileSync(0, 'utf8')
+  .split('\n')
+  .map((line) => line.trim())
+  .filter(Boolean);
+
+let parsers;
+try {
+  parsers = parseCommitParsers(readFileSync(CLIFF, 'utf8'));
+} catch (error) {
+  console.error(`::error::Could not read ${CLIFF}: ${error.message}`);
+  process.exit(2);
+}
+
+const problems = selfCheck(parsers);
+if (problems.length > 0) {
+  console.error(`::error::This check no longer agrees with ${CLIFF}, so it is not in`);
+  console.error('::error::a position to judge anything and will not pretend to be.');
+  console.error('::error::Either the parsing in scripts/check-pr-title.mjs has been');
+  console.error(`::error::outgrown by the format of ${CLIFF}, or which types reach`);
+  console.error('::error::the changelog was changed deliberately -- in which case');
+  console.error('::error::update the expectations in selfCheck to match the new');
+  console.error('::error::policy. Failing here is the point: silently classifying');
+  console.error('::error::every title as "not in the changelog" would leave a green');
+  console.error('::error::check guarding nothing.');
+  for (const problem of problems) console.error(`  - ${problem}`);
+  process.exit(2);
+}
+
+const parser = classify(parsers, title);
+if (!parser) {
+  console.error(`::error::"${title}" matched no parser in ${CLIFF}.`);
+  process.exit(2);
+}
+
+if (parser.skip) {
+  console.log(
+    `"${title}" is skipped by ${CLIFF}; it will not appear in the changelog.`
+  );
+  process.exit(0);
+}
+
+if (parser.message === CATCH_ALL) {
+  console.error(`::error::"${title}" is not a conventional commit subject.`);
+  console.error(`::error::${CLIFF}'s catch-all parser is not skipped, so this would`);
+  console.error('::error::appear in the user-facing changelog under "Other" rather');
+  console.error('::error::than being filtered out. Prefix it with a type:');
+  console.error('::error::feat, fix, perf, revert, docs, build, ci, test, refactor,');
+  console.error('::error::style or chore.');
+  process.exit(1);
+}
+
+const userFacing = changed.filter(isUserFacing);
+if (userFacing.length > 0) {
+  console.log(
+    `"${title}" belongs in the changelog, and ${userFacing.length} user-facing`
+  );
+  console.log(`file(s) changed: ${userFacing.join(', ')}`);
+  process.exit(0);
+}
+
+console.error(`::error::"${title}" would appear in the user-facing changelog, but`);
+console.error('::error::this pull request changes nothing a user of the extension');
+console.error('::error::can observe -- no files under src/ outside src/test/, and');
+console.error('::error::no change to package.json.');
+console.error('::error::');
+console.error('::error::Retitle it with a type cliff.toml skips. ci for workflows');
+console.error('::error::and release tooling, build for dependencies and packaging,');
+console.error('::error::docs for documentation, test, refactor, style or chore.');
+console.error('::error::');
+console.error(`::error::The title becomes the squash commit subject, so "${title}"`);
+console.error('::error::is what readers of CHANGELOG.md and the marketplace');
+console.error('::error::changelog tab would be shown.');
+console.error('');
+console.error(`Changed files (${changed.length}):`);
+for (const path of changed) console.error(`  ${path}`);
+process.exit(1);

--- a/scripts/check-pr-title.mjs
+++ b/scripts/check-pr-title.mjs
@@ -236,10 +236,11 @@ if (parser.skip && !protectedBreaking) {
 }
 
 if (parser.message === CATCH_ALL) {
-  console.error(`::error::"${title}" is not a conventional commit subject.`);
-  console.error(`::error::${CLIFF}'s catch-all parser is not skipped, so this would`);
-  console.error('::error::appear in the user-facing changelog under "Other" rather');
-  console.error('::error::than being filtered out. Prefix it with a type:');
+  console.error(`::error::"${title}" carries no type that ${CLIFF} recognises,`);
+  console.error('::error::whether because it has none or because that one is not in');
+  console.error(`::error::the list. ${CLIFF}'s catch-all parser is not skipped, so it`);
+  console.error('::error::would appear in the user-facing changelog under "Other"');
+  console.error('::error::rather than being filtered out. Use a known type:');
   console.error('::error::feat, fix, perf, revert, docs, build, ci, test, refactor,');
   console.error('::error::style or chore.');
   process.exit(1);

--- a/scripts/check-pr-title.mjs
+++ b/scripts/check-pr-title.mjs
@@ -9,7 +9,8 @@
 // hook or linter currently touches -- decides what users see in CHANGELOG.md and in
 // the marketplace changelog tab, while gitlint only ever sees local commit messages.
 //
-// Two ways that goes wrong, both of which have happened here:
+// Four ways that goes wrong. The first has happened here twice; the rest are shapes
+// git-cliff was confirmed to accept, caught in review before they could:
 //
 //   - A change with no user-facing effect titled `feat:` or `fix:`. Release tooling
 //     and CI work landed as "feat: draft releases so they carry the vsix" and
@@ -27,11 +28,16 @@
 //     parser, so "ci!: drop the release workflow" still reaches the changelog under
 //     Continuous Integration. Confirmed against git-cliff 2.13.1: with the flag on
 //     both `ci!:` and `docs(scope)!:` are rendered, and with it off both vanish.
+//   - A type outside this repository's vocabulary. Because the parsers match on
+//     prefix, `^feat` also accepts "feature:" and `^fix` accepts "fixes:", either of
+//     which lands in a user-facing group under a type gitlint would have rejected on
+//     a commit message -- and gitlint never sees a title.
 //
-// Derived from cliff.toml rather than from a hardcoded list of types, so that
-// changing which types are skipped -- or turning breaking protection off -- changes
-// this check too. The parse is asserted against known cases below; a cliff.toml this
-// cannot read fails the run instead of passing it.
+// Derived from configuration rather than from hardcoded lists. Which types reach the
+// changelog, and whether a breaking marker overrides a skip, come from cliff.toml; the
+// accepted type vocabulary comes from .gitlint. The cliff.toml parse is asserted
+// against known cases below, and a configuration this cannot read fails the run rather
+// than passing everything.
 //
 // Usage:
 //   node scripts/check-pr-title.mjs "<pr title>" < changed-files.txt
@@ -42,6 +48,7 @@ import { readFileSync } from 'node:fs';
 
 const CLIFF = 'cliff.toml';
 const CATCH_ALL = '^.*';
+const UNPARSABLE = Symbol('unparsable');
 
 // A breaking change in the Conventional Commits sense: `!` immediately before the
 // colon, after the type or the scope. The other spelling, a `BREAKING CHANGE:` footer,
@@ -51,8 +58,35 @@ const BREAKING = /^[a-z]+(\([^()]+\))?!:/;
 // A conventional subject: type, optional scope, optional `!`, then a colon, a space,
 // and something. cliff's own parsers are looser than this on purpose -- `^feat` is a
 // prefix match that also accepts "feat add setting" -- so the shape is checked
-// separately for any title that reaches the changelog.
-const CONVENTIONAL = /^[a-z]+(\([^()]+\))?!?: \S/;
+// separately for any title that reaches the changelog. Group 1 is the type, which is
+// then checked against the vocabulary below for the same reason: `^feat` also accepts
+// "feature:" and `^fix` accepts "fixes:".
+const CONVENTIONAL = /^([a-z]+)(\([^()]+\))?!?: \S/;
+
+const GITLINT = '.gitlint';
+
+// The commit types this repository accepts. gitlint's
+// contrib-title-conventional-commits rule enforces this vocabulary on every local
+// commit message, and a pull request title never passes through gitlint -- GitHub
+// composes the squash subject server-side, after every hook has run -- so this check is
+// the only place the same list can be applied to it.
+//
+// Taken from `[contrib-title-conventional-commits] types` in .gitlint when that is set,
+// so overriding the vocabulary there changes this check too. It is commented out today,
+// which means gitlint is enforcing its own default; the fallback is that default.
+const DEFAULT_TYPES = [
+  'fix',
+  'feat',
+  'chore',
+  'docs',
+  'style',
+  'refactor',
+  'perf',
+  'test',
+  'revert',
+  'ci',
+  'build',
+];
 
 // Note on breaking footers: the other way to declare a breaking change is a
 // `BREAKING CHANGE:` footer in the commit body. GitHub builds the squash body from the
@@ -129,12 +163,45 @@ function parseCommitParsers(toml) {
  * Read `protect_breaking_commits` out of cliff.toml.
  *
  * When it is on, git-cliff exempts breaking changes from a parser that would skip
- * them, so a breaking title reaches the changelog whatever its type. Absent means off,
- * which is git-cliff's own default, so an unreadable or missing setting makes this
- * check *less* strict rather than rejecting titles cliff would happily drop.
+ * them, so a breaking title reaches the changelog whatever its type.
+ *
+ * Returns `true`, `false`, or `UNPARSABLE`. Three cases, deliberately distinct:
+ * the flag reads cleanly; the key is absent, which is git-cliff's own default of off;
+ * or the key is present in a form this scan does not understand. That last case used
+ * to fall in with "absent" and quietly disagree with git-cliff about every breaking
+ * title, so it now stops the run instead -- the same reasoning as `selfCheck`.
  */
 function parseProtectBreaking(toml) {
-  return /^[ \t]*protect_breaking_commits[ \t]*=[ \t]*true[ \t]*$/m.test(toml);
+  const setting =
+    /^[ \t]*protect_breaking_commits[ \t]*=[ \t]*(true|false)[ \t]*(#.*)?$/m;
+  const match = setting.exec(toml);
+  if (match) return match[1] === 'true';
+  if (/protect_breaking_commits/.test(toml)) return UNPARSABLE;
+  return false;
+}
+
+/**
+ * Read the accepted commit types out of .gitlint, falling back to gitlint's default.
+ *
+ * Section-scoped on purpose: `types` is a plausible key elsewhere in that file, and the
+ * only one that governs commit types is the one inside the contrib rule's own section.
+ * The commented-out example in .gitlint does not match, because a comment cannot open a
+ * section header. An empty list is treated as unreadable rather than as "reject
+ * everything".
+ */
+function parseGitlintTypes(ini) {
+  const header = /^\[contrib-title-conventional-commits\][ \t]*$/m.exec(ini);
+  if (!header) return DEFAULT_TYPES;
+  const rest = ini.slice(header.index + header[0].length);
+  const nextSection = /^\[/m.exec(rest);
+  const block = nextSection ? rest.slice(0, nextSection.index) : rest;
+  const declared = /^[ \t]*types[ \t]*=[ \t]*(.+)$/m.exec(block);
+  if (!declared) return DEFAULT_TYPES;
+  const types = declared[1]
+    .split(',')
+    .map((type) => type.trim().toLowerCase())
+    .filter(Boolean);
+  return types.length > 0 ? types : UNPARSABLE;
 }
 
 /** Classify a subject the way git-cliff does: first matching parser wins. */
@@ -204,6 +271,34 @@ try {
 const parsers = parseCommitParsers(toml);
 const protectBreaking = parseProtectBreaking(toml);
 
+let acceptedTypes;
+try {
+  acceptedTypes = parseGitlintTypes(readFileSync(GITLINT, 'utf8'));
+} catch {
+  // No .gitlint at all is not a problem: gitlint's default vocabulary is what the
+  // contrib rule enforces when the section is absent, which is the fallback anyway.
+  acceptedTypes = DEFAULT_TYPES;
+}
+
+if (acceptedTypes === UNPARSABLE) {
+  console.error(`::error::${GITLINT} declares an empty commit-type list, so this`);
+  console.error('::error::check cannot tell which types are acceptable. Either list');
+  console.error('::error::the types under [contrib-title-conventional-commits] or');
+  console.error("::error::remove the key to fall back to gitlint's default.");
+  process.exit(2);
+}
+
+if (protectBreaking === UNPARSABLE) {
+  console.error(`::error::${CLIFF} sets protect_breaking_commits in a form this`);
+  console.error('::error::script cannot read, so it cannot tell whether a breaking');
+  console.error('::error::title on a skipped type reaches the changelog. Guessing');
+  console.error('::error::would put this check into silent disagreement with');
+  console.error('::error::git-cliff, which is worse than stopping. Expected a line');
+  console.error('::error::reading `protect_breaking_commits = true` or `= false`,');
+  console.error('::error::with an optional trailing comment.');
+  process.exit(2);
+}
+
 const problems = selfCheck(parsers);
 if (problems.length > 0) {
   console.error(`::error::This check no longer agrees with ${CLIFF}, so it is not in`);
@@ -241,12 +336,12 @@ if (parser.message === CATCH_ALL) {
   console.error(`::error::the list. ${CLIFF}'s catch-all parser is not skipped, so it`);
   console.error('::error::would appear in the user-facing changelog under "Other"');
   console.error('::error::rather than being filtered out. Use a known type:');
-  console.error('::error::feat, fix, perf, revert, docs, build, ci, test, refactor,');
-  console.error('::error::style or chore.');
+  console.error(`::error::${acceptedTypes.join(', ')}.`);
   process.exit(1);
 }
 
-if (!CONVENTIONAL.test(title)) {
+const shape = CONVENTIONAL.exec(title);
+if (!shape) {
   console.error(`::error::"${title}" reaches the changelog, but it is not a`);
   console.error('::error::conventional subject: that is type, an optional (scope),');
   console.error('::error::an optional !, then a colon, a space and a description.');
@@ -256,6 +351,23 @@ if (!CONVENTIONAL.test(title)) {
   console.error('::error::because the conventional parse then fails git-cliff prints');
   console.error('::error::the raw subject -- the changelog entry reads');
   console.error('::error::"- feat add setting", type included.');
+  process.exit(1);
+}
+
+const type = shape[1];
+if (!acceptedTypes.includes(type)) {
+  console.error(`::error::"${title}" reaches the changelog under the type "${type}",`);
+  console.error(`::error::which is not one this repository uses. ${GITLINT} accepts:`);
+  console.error(`::error::${acceptedTypes.join(', ')}.`);
+  console.error('::error::');
+  console.error(`::error::${CLIFF}'s parsers match on prefix, so "feature:" is filed`);
+  console.error('::error::as a feature and "fixes:" as a fix even though neither is a');
+  console.error('::error::type in that list. gitlint enforces it on commit messages,');
+  console.error(
+    '::error::but GitHub composes the squash subject from this title after'
+  );
+  console.error('::error::gitlint has run, so the title is the only place it can be');
+  console.error('::error::applied.');
   process.exit(1);
 }
 

--- a/scripts/check-pr-title.mjs
+++ b/scripts/check-pr-title.mjs
@@ -18,7 +18,10 @@
 //     by accident while looking at something else.
 //   - A title that is not conventional at all. cliff.toml ends with a catch-all
 //     `^.*` parser that is *not* skipped, so an unrecognised prefix does not fall out
-//     of the changelog -- it lands in "Other".
+//     of the changelog -- it lands in "Other". A subject that opens with a kept type
+//     but drops the colon is worse still: cliff's parsers are prefix matches, so
+//     "feat add setting" is filed under Features, and since the conventional parse
+//     then fails the raw subject is printed verbatim, type and all.
 //   - A breaking marker on a type that is otherwise skipped. cliff.toml sets
 //     `protect_breaking_commits`, which exempts breaking changes from a skipping
 //     parser, so "ci!: drop the release workflow" still reaches the changelog under
@@ -42,8 +45,21 @@ const CATCH_ALL = '^.*';
 
 // A breaking change in the Conventional Commits sense: `!` immediately before the
 // colon, after the type or the scope. The other spelling, a `BREAKING CHANGE:` footer,
-// cannot be seen from here -- see the note on breaking footers further down.
+// cannot be seen from here -- see the note below.
 const BREAKING = /^[a-z]+(\([^()]+\))?!:/;
+
+// A conventional subject: type, optional scope, optional `!`, then a colon, a space,
+// and something. cliff's own parsers are looser than this on purpose -- `^feat` is a
+// prefix match that also accepts "feat add setting" -- so the shape is checked
+// separately for any title that reaches the changelog.
+const CONVENTIONAL = /^[a-z]+(\([^()]+\))?!?: \S/;
+
+// Note on breaking footers: the other way to declare a breaking change is a
+// `BREAKING CHANGE:` footer in the commit body. GitHub builds the squash body from the
+// branch's commit messages on this repository (squash_merge_commit_message is
+// COMMIT_MESSAGES), so a footer in one of those commits can make the squashed commit
+// breaking while the title says nothing, and this check is handed nothing but the
+// title. gitlint does see those commit messages, which is the nearest thing to cover.
 
 /**
  * Files that are shipped in the VSIX or decide what the VSIX contains, and so can
@@ -226,6 +242,19 @@ if (parser.message === CATCH_ALL) {
   console.error('::error::than being filtered out. Prefix it with a type:');
   console.error('::error::feat, fix, perf, revert, docs, build, ci, test, refactor,');
   console.error('::error::style or chore.');
+  process.exit(1);
+}
+
+if (!CONVENTIONAL.test(title)) {
+  console.error(`::error::"${title}" reaches the changelog, but it is not a`);
+  console.error('::error::conventional subject: that is type, an optional (scope),');
+  console.error('::error::an optional !, then a colon, a space and a description.');
+  console.error('::error::');
+  console.error(`::error::${CLIFF}'s parsers are prefix matches, so a subject like`);
+  console.error('::error::"feat add setting" is grouped under Features anyway, and');
+  console.error('::error::because the conventional parse then fails git-cliff prints');
+  console.error('::error::the raw subject -- the changelog entry reads');
+  console.error('::error::"- feat add setting", type included.');
   process.exit(1);
 }
 

--- a/scripts/check-pr-title.mjs
+++ b/scripts/check-pr-title.mjs
@@ -19,11 +19,16 @@
 //   - A title that is not conventional at all. cliff.toml ends with a catch-all
 //     `^.*` parser that is *not* skipped, so an unrecognised prefix does not fall out
 //     of the changelog -- it lands in "Other".
+//   - A breaking marker on a type that is otherwise skipped. cliff.toml sets
+//     `protect_breaking_commits`, which exempts breaking changes from a skipping
+//     parser, so "ci!: drop the release workflow" still reaches the changelog under
+//     Continuous Integration. Confirmed against git-cliff 2.13.1: with the flag on
+//     both `ci!:` and `docs(scope)!:` are rendered, and with it off both vanish.
 //
 // Derived from cliff.toml rather than from a hardcoded list of types, so that
-// changing which types are skipped changes this check too. The parse is asserted
-// against known cases below; a cliff.toml this cannot read fails the run instead of
-// passing it.
+// changing which types are skipped -- or turning breaking protection off -- changes
+// this check too. The parse is asserted against known cases below; a cliff.toml this
+// cannot read fails the run instead of passing it.
 //
 // Usage:
 //   node scripts/check-pr-title.mjs "<pr title>" < changed-files.txt
@@ -34,6 +39,11 @@ import { readFileSync } from 'node:fs';
 
 const CLIFF = 'cliff.toml';
 const CATCH_ALL = '^.*';
+
+// A breaking change in the Conventional Commits sense: `!` immediately before the
+// colon, after the type or the scope. The other spelling, a `BREAKING CHANGE:` footer,
+// cannot be seen from here -- see the note on breaking footers further down.
+const BREAKING = /^[a-z]+(\([^()]+\))?!:/;
 
 /**
  * Files that are shipped in the VSIX or decide what the VSIX contains, and so can
@@ -99,6 +109,18 @@ function parseCommitParsers(toml) {
   return parsers;
 }
 
+/**
+ * Read `protect_breaking_commits` out of cliff.toml.
+ *
+ * When it is on, git-cliff exempts breaking changes from a parser that would skip
+ * them, so a breaking title reaches the changelog whatever its type. Absent means off,
+ * which is git-cliff's own default, so an unreadable or missing setting makes this
+ * check *less* strict rather than rejecting titles cliff would happily drop.
+ */
+function parseProtectBreaking(toml) {
+  return /^[ \t]*protect_breaking_commits[ \t]*=[ \t]*true[ \t]*$/m.test(toml);
+}
+
 /** Classify a subject the way git-cliff does: first matching parser wins. */
 function classify(parsers, subject) {
   for (const parser of parsers) {
@@ -155,13 +177,16 @@ const changed = readFileSync(0, 'utf8')
   .map((line) => line.trim())
   .filter(Boolean);
 
-let parsers;
+let toml;
 try {
-  parsers = parseCommitParsers(readFileSync(CLIFF, 'utf8'));
+  toml = readFileSync(CLIFF, 'utf8');
 } catch (error) {
   console.error(`::error::Could not read ${CLIFF}: ${error.message}`);
   process.exit(2);
 }
+
+const parsers = parseCommitParsers(toml);
+const protectBreaking = parseProtectBreaking(toml);
 
 const problems = selfCheck(parsers);
 if (problems.length > 0) {
@@ -184,7 +209,10 @@ if (!parser) {
   process.exit(2);
 }
 
-if (parser.skip) {
+const breaking = BREAKING.test(title);
+const protectedBreaking = breaking && protectBreaking;
+
+if (parser.skip && !protectedBreaking) {
   console.log(
     `"${title}" is skipped by ${CLIFF}; it will not appear in the changelog.`
   );
@@ -215,9 +243,18 @@ console.error('::error::this pull request changes nothing a user of the extensio
 console.error('::error::can observe -- nothing under src/ outside src/test/, and');
 console.error(`::error::none of ${[...PACKAGED_FILES].join(', ')}.`);
 console.error('::error::');
-console.error('::error::Retitle it with a type cliff.toml skips. ci for workflows');
-console.error('::error::and release tooling, build for dependencies and packaging,');
-console.error('::error::docs for documentation, test, refactor, style or chore.');
+if (protectedBreaking) {
+  console.error(`::error::${CLIFF} skips ${parser.message} titles, but it also sets`);
+  console.error('::error::protect_breaking_commits, which exempts breaking changes');
+  console.error('::error::from a skipping parser -- so the `!` is the reason this');
+  console.error('::error::title reaches the changelog. Drop it if nothing a user of');
+  console.error('::error::the extension depends on breaks, and describe the impact');
+  console.error('::error::on contributors in the body instead.');
+} else {
+  console.error('::error::Retitle it with a type cliff.toml skips. ci for workflows');
+  console.error('::error::and release tooling, build for dependencies and packaging,');
+  console.error('::error::docs for documentation, test, refactor, style or chore.');
+}
 console.error('::error::');
 console.error(`::error::The title becomes the squash commit subject, so "${title}"`);
 console.error('::error::is what readers of CHANGELOG.md and the marketplace');

--- a/scripts/check-pr-title.mjs
+++ b/scripts/check-pr-title.mjs
@@ -36,18 +36,37 @@ const CLIFF = 'cliff.toml';
 const CATCH_ALL = '^.*';
 
 /**
- * Paths whose contents can change what a user of the extension experiences.
+ * Files that are shipped in the VSIX or decide what the VSIX contains, and so can
+ * change what a user of the installed extension experiences.
  *
- * Deliberately narrow: `src/` is the extension, and `package.json` carries the
- * contributed commands, settings and engine range. Everything else in the repository
- * -- workflows, scripts, the Makefile, docs, configuration -- can be rewritten
- * wholesale without altering the installed extension's behaviour, which is exactly
- * why a `feat:` covering only those files is a mislabel.
+ *   - `package.json` -- the manifest: contributed commands, settings, engine range.
+ *   - `icon.png` -- the extension's visible identity in the marketplace and the
+ *     Extensions view. `.vscodeignore` unignores it and the manifest names it.
+ *   - `.vscodeignore` -- an `**` deny-all followed by `!` allowances, so it decides
+ *     what `vsce package` puts in the VSIX. Editing it changes the installed bytes.
  *
- * `src/test/` is excluded: tests are `test:` in this convention, and cliff skips it.
+ * `README.md`, `CHANGELOG.md` and `LICENSE` are also unignored, and are deliberately
+ * *not* here. They document the extension rather than being it, their conventional
+ * type is `docs:`, and cliff.toml skips that -- so including them could only ever
+ * manufacture a pass for something like `feat: reword the README`.
+ *
+ * Everything else in the repository -- workflows, scripts, the Makefile, docs,
+ * tooling configuration -- can be rewritten wholesale without altering the installed
+ * extension, which is exactly why a `feat:` covering only those files is a mislabel.
+ * `src/test/` is excluded for the same reason: tests are `test:`, which cliff skips.
+ *
+ * Known limitation, whole-file granularity: a `package.json` diff touching only npm
+ * scripts or devDependency ranges counts as user-facing here. Narrowing it to the
+ * manifest keys that users can observe would mean reading the base revision of the
+ * file, and the fail-open half of that (base unavailable) leaves the same hole while
+ * the fail-closed half adds a new way for this check to block a pull request. The
+ * exposure is small in practice because dependency bumps and version bumps arrive
+ * under types cliff.toml skips, so they never reach this predicate at all.
  */
+const PACKAGED_FILES = new Set(['package.json', 'icon.png', '.vscodeignore']);
+
 function isUserFacing(path) {
-  if (path === 'package.json') return true;
+  if (PACKAGED_FILES.has(path)) return true;
   return path.startsWith('src/') && !path.startsWith('src/test/');
 }
 
@@ -193,8 +212,8 @@ if (userFacing.length > 0) {
 
 console.error(`::error::"${title}" would appear in the user-facing changelog, but`);
 console.error('::error::this pull request changes nothing a user of the extension');
-console.error('::error::can observe -- no files under src/ outside src/test/, and');
-console.error('::error::no change to package.json.');
+console.error('::error::can observe -- nothing under src/ outside src/test/, and');
+console.error(`::error::none of ${[...PACKAGED_FILES].join(', ')}.`);
 console.error('::error::');
 console.error('::error::Retitle it with a type cliff.toml skips. ci for workflows');
 console.error('::error::and release tooling, build for dependencies and packaging,');

--- a/scripts/test-check-pr-title.sh
+++ b/scripts/test-check-pr-title.sh
@@ -49,6 +49,11 @@ expect 0 'fix: restore colors on toggle' src/extension.ts
 expect 0 'perf: avoid a redundant write' src/extension.ts
 expect 0 'feat(extension)!: change the default' src/extension.ts
 
+# Shipped assets and the file that decides what ships are user-facing on their own:
+# both are installed alongside the extension, so a release note about either is real.
+expect 0 'feat: redraw the icon' icon.png
+expect 0 'fix: restore the missing dist directory in the vsix' .vscodeignore
+
 # --- Titles cliff.toml skips, so the diff does not matter --------------------------
 expect 0 'ci: add prep-release and tag make targets' Makefile scripts/prep-release.sh
 expect 0 'docs: document settings' README.md

--- a/scripts/test-check-pr-title.sh
+++ b/scripts/test-check-pr-title.sh
@@ -62,6 +62,14 @@ expect 0 'chore(deps-dev): bump sinon' package-lock.json
 expect 0 'test: cover the toggle path' src/test/unit/extension.test.ts
 expect 0 'refactor: extract a helper' src/extension.ts
 
+# --- Breaking titles, which cliff.toml protects from its own skips -----------------
+# protect_breaking_commits means the `!` outranks the parser, so an internal type with
+# a breaking marker is changelog-visible and has to earn its place like any other.
+expect 1 'ci!: drop the release workflow' .github/workflows/publish.yml
+expect 1 'docs(guide)!: rewrite the contributing guide' CONTRIBUTING.md
+expect 0 'ci!: drop the release workflow' src/extension.ts
+expect 0 'feat!: change the default' src/extension.ts
+
 # --- The two that actually reached main -------------------------------------------
 expect 1 'feat: draft releases so they carry the vsix' \
   .github/workflows/publish.yml CONTRIBUTING.md
@@ -81,6 +89,20 @@ if printf 'src/extension.ts\n' | node "$CHECKER" > /dev/null 2>&1; then
   echo "FAIL: expected a usage error with no title argument" >&2
   FAILURES=$((FAILURES + 1))
 fi
+
+# --- protect_breaking_commits is read from the config, not assumed -----------------
+# The two breaking cases above fail only because cliff.toml turns that flag on. With it
+# off, git-cliff drops those commits entirely (verified against git-cliff 2.13.1), so
+# the checker has to stop objecting to them or it rejects titles cliff would not print.
+sed 's/^protect_breaking_commits = true$/protect_breaking_commits = false/' cliff.toml \
+  > unprotected.toml
+mv unprotected.toml cliff.toml
+if grep -q '^protect_breaking_commits = true$' cliff.toml; then
+  echo "FAIL: protect_breaking_commits was not turned off in the copy" >&2
+  FAILURES=$((FAILURES + 1))
+fi
+expect 0 'ci!: drop the release workflow' .github/workflows/publish.yml
+cp "$REPO_ROOT/cliff.toml" cliff.toml
 
 # --- Degradation: a cliff.toml the checker cannot read must fail, not pass ---------
 # Without the self-check the checker asserts, removing commit_parsers would classify

--- a/scripts/test-check-pr-title.sh
+++ b/scripts/test-check-pr-title.sh
@@ -83,6 +83,8 @@ expect 1 'perf: speed up packaging' scripts/normalize-vsix.mjs
 # --- Non-conventional titles, which cliff's catch-all keeps ------------------------
 expect 1 'add a thing without a type' src/extension.ts
 expect 1 'Update README' README.md
+# Conventionally shaped, but no parser claims `wip`, so it lands in Other too.
+expect 1 'wip: hack on the toggle' src/extension.ts
 
 # Malformed but opening with a kept type, so cliff's prefix match files them under a
 # user-facing group and then prints the raw subject. Backing them with src/ changes is

--- a/scripts/test-check-pr-title.sh
+++ b/scripts/test-check-pr-title.sh
@@ -54,6 +54,15 @@ expect 0 'feat(extension)!: change the default' src/extension.ts
 expect 0 'feat: redraw the icon' icon.png
 expect 0 'fix: restore the missing dist directory in the vsix' .vscodeignore
 
+# A rename reaches the checker as both of its paths, so a file moved out of src/ is
+# still recognised by where it came from. The workflow is what supplies the old path.
+expect 0 'fix: relocate the toggle helper' lib/toggle.ts src/toggle.ts
+if ! grep -q 'previous_filename' "$REPO_ROOT/.github/workflows/pr-title.yml"; then
+  echo "FAIL: pr-title.yml no longer emits previous_filename, so the rename case" >&2
+  echo "      above cannot occur in CI and proves nothing" >&2
+  FAILURES=$((FAILURES + 1))
+fi
+
 # --- Titles cliff.toml skips, so the diff does not matter --------------------------
 expect 0 'ci: add prep-release and tag make targets' Makefile scripts/prep-release.sh
 expect 0 'docs: document settings' README.md
@@ -86,6 +95,13 @@ expect 1 'Update README' README.md
 # Conventionally shaped, but no parser claims `wip`, so it lands in Other too.
 expect 1 'wip: hack on the toggle' src/extension.ts
 
+# Types cliff's prefix parsers accept but this repository does not. These reach a
+# user-facing group -- `^feat` matches "feature", `^fix` matches "fixes" -- so the type
+# has to be one gitlint would have accepted had it ever seen the title.
+expect 1 'feature: add a setting' src/extension.ts
+expect 1 'fixes: restore startup' src/extension.ts
+expect 1 'features(ui): add a setting' src/extension.ts
+
 # Malformed but opening with a kept type, so cliff's prefix match files them under a
 # user-facing group and then prints the raw subject. Backing them with src/ changes is
 # deliberate: without a shape check these are the cases that slip through.
@@ -117,6 +133,26 @@ if grep -q '^protect_breaking_commits = true$' cliff.toml; then
   FAILURES=$((FAILURES + 1))
 fi
 expect 0 'ci!: drop the release workflow' .github/workflows/publish.yml
+
+# An inline comment is valid TOML and must not read as "off". Before this was handled,
+# the flag silently parsed as false and every breaking internal title passed.
+sed 's/^protect_breaking_commits = false$/protect_breaking_commits = true # keep these/' \
+  cliff.toml > commented.toml
+mv commented.toml cliff.toml
+if ! grep -q 'protect_breaking_commits = true # keep these' cliff.toml; then
+  echo "FAIL: the inline-comment form was not written to the copy" >&2
+  FAILURES=$((FAILURES + 1))
+fi
+expect 1 'ci!: drop the release workflow' .github/workflows/publish.yml
+
+# A form the scan cannot read must stop the run rather than default to off, which would
+# be a silent disagreement with git-cliff on every breaking title.
+sed 's/^protect_breaking_commits = true # keep these$/protect_breaking_commits = "yes"/' \
+  cliff.toml > weird.toml
+mv weird.toml cliff.toml
+expect 2 'ci!: drop the release workflow' .github/workflows/publish.yml
+expect 2 'feat: add a startHidden setting' src/extension.ts
+
 cp "$REPO_ROOT/cliff.toml" cliff.toml
 
 # --- Degradation: a cliff.toml the checker cannot read must fail, not pass ---------

--- a/scripts/test-check-pr-title.sh
+++ b/scripts/test-check-pr-title.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+
+# Tests for scripts/check-pr-title.mjs.
+#
+# The checker exists because two mislabelled titles reached main, so the cases that
+# actually happened are in here by name. The degradation cases matter as much as the
+# ordinary ones: a checker that quietly stops checking is worse than no checker, since
+# it produces a green mark that means nothing.
+#
+# Everything runs against a *copy* of cliff.toml in a temporary directory. The checker
+# reads `cliff.toml` from the working directory, so changing directory is enough to
+# swap the configuration under it. That matters because some cases below need a broken
+# config, and `make check` -- which runs this file -- is the pre-release gate. Editing
+# the real cliff.toml in place would put a window, however short, where an interrupted
+# release run leaves the repository holding a mangled config.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECKER="$REPO_ROOT/scripts/check-pr-title.mjs"
+WORKSPACE=""
+FAILURES=0
+
+cleanup() {
+  [ -n "$WORKSPACE" ] && rm -rf "$WORKSPACE"
+}
+trap cleanup EXIT
+
+WORKSPACE="$(mktemp -d)"
+cp "$REPO_ROOT/cliff.toml" "$WORKSPACE/cliff.toml"
+cd "$WORKSPACE"
+
+# expect <want-rc> <title> [changed files...]
+expect() {
+  local want="$1" title="$2"
+  shift 2
+  local got=0
+  printf '%s\n' "$@" | node "$CHECKER" "$title" > /dev/null 2>&1 || got=$?
+  if [ "$got" != "$want" ]; then
+    echo "FAIL: expected $want, got $got for: $title" >&2
+    printf '  files: %s\n' "$*" >&2
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+# --- Titles that belong in the changelog, backed by user-facing changes -------------
+expect 0 'feat: add a startHidden setting' src/extension.ts package.json
+expect 0 'fix: restore colors on toggle' src/extension.ts
+expect 0 'perf: avoid a redundant write' src/extension.ts
+expect 0 'feat(extension)!: change the default' src/extension.ts
+
+# --- Titles cliff.toml skips, so the diff does not matter --------------------------
+expect 0 'ci: add prep-release and tag make targets' Makefile scripts/prep-release.sh
+expect 0 'docs: document settings' README.md
+expect 0 'build(deps): bump undici' package-lock.json
+expect 0 'chore(deps-dev): bump sinon' package-lock.json
+expect 0 'test: cover the toggle path' src/test/unit/extension.test.ts
+expect 0 'refactor: extract a helper' src/extension.ts
+
+# --- The two that actually reached main -------------------------------------------
+expect 1 'feat: draft releases so they carry the vsix' \
+  .github/workflows/publish.yml CONTRIBUTING.md
+expect 1 'feat: add prep-release and tag make targets' Makefile scripts/prep-release.sh
+
+# --- Other user-facing claims with nothing user-facing in the diff -----------------
+expect 1 'fix: correct a workflow condition' .github/workflows/ci.yml
+expect 1 'feat: only tests changed' src/test/unit/foo.test.ts
+expect 1 'perf: speed up packaging' scripts/normalize-vsix.mjs
+
+# --- Non-conventional titles, which cliff's catch-all keeps ------------------------
+expect 1 'add a thing without a type' src/extension.ts
+expect 1 'Update README' README.md
+
+# --- Misuse of the checker itself --------------------------------------------------
+if printf 'src/extension.ts\n' | node "$CHECKER" > /dev/null 2>&1; then
+  echo "FAIL: expected a usage error with no title argument" >&2
+  FAILURES=$((FAILURES + 1))
+fi
+
+# --- Degradation: a cliff.toml the checker cannot read must fail, not pass ---------
+# Without the self-check the checker asserts, removing commit_parsers would classify
+# every title as "not in the changelog" and every run would come back green.
+sed '/^commit_parsers = \[/,/^\]/d' cliff.toml > stripped.toml
+mv stripped.toml cliff.toml
+expect 2 'feat: a real feature' src/extension.ts
+
+# Policy changed rather than format outgrown: marking feat as skipped must also stop
+# the checker, because its expectations no longer describe the configuration.
+cp "$REPO_ROOT/cliff.toml" cliff.toml
+sed 's|{ message = "\^feat", group = "<!-- 00 -->✨ Features" },|{ message = "^feat", group = "<!-- 00 -->✨ Features", skip = true },|' \
+  cliff.toml > policy.toml
+mv policy.toml cliff.toml
+expect 2 'feat: a real feature' src/extension.ts
+
+# Sanity: the copy really was modified, so the two cases above tested what they claim.
+if grep -q '"\^feat", group = "<!-- 00 -->✨ Features" },' cliff.toml; then
+  echo "FAIL: the cliff.toml copy was not modified; degradation cases proved nothing" >&2
+  FAILURES=$((FAILURES + 1))
+fi
+
+if [ "$FAILURES" -ne 0 ]; then
+  echo "check-pr-title.mjs: $FAILURES test(s) failed" >&2
+  exit 1
+fi
+
+echo "check-pr-title.mjs test passed"

--- a/scripts/test-check-pr-title.sh
+++ b/scripts/test-check-pr-title.sh
@@ -84,6 +84,19 @@ expect 1 'perf: speed up packaging' scripts/normalize-vsix.mjs
 expect 1 'add a thing without a type' src/extension.ts
 expect 1 'Update README' README.md
 
+# Malformed but opening with a kept type, so cliff's prefix match files them under a
+# user-facing group and then prints the raw subject. Backing them with src/ changes is
+# deliberate: without a shape check these are the cases that slip through.
+expect 1 'feat add setting' src/extension.ts
+expect 1 'fixing startup' src/extension.ts
+expect 1 'feat:no space after the colon' src/extension.ts
+expect 1 'fixup! wip' src/extension.ts
+
+# But the shape is required only of titles that reach the changelog. A bare version
+# subject is what `npm version` writes and cliff.toml skips it by name, so demanding a
+# conventional shape everywhere would reject a release commit cliff never prints.
+expect 0 '0.4.2' package.json CHANGELOG.md
+
 # --- Misuse of the checker itself --------------------------------------------------
 if printf 'src/extension.ts\n' | node "$CHECKER" > /dev/null 2>&1; then
   echo "FAIL: expected a usage error with no title argument" >&2


### PR DESCRIPTION
## The gap

The pull request title is unguarded and load-bearing.

This repository squash-merges, and GitHub uses the **title** as the squash subject whenever a branch carries more than one commit. That subject is what git-cliff reads when it writes `CHANGELOG.md` and the marketplace changelog tab. `gitlint` runs on local commit messages and never sees the title, so nothing in the repository looked at the one field that decides what users are shown.

Two mislabels reached main because of it:

| Title as merged | What it actually changed |
| --- | --- |
| `feat: draft releases so they carry the vsix` (#243) | `publish.yml`, `Makefile`, `CONTRIBUTING.md` |
| `feat: add prep-release and tag make targets` (#252) | `Makefile`, `scripts/` |

Both are release tooling with no user-visible effect, and both would have appeared under **✨ Features** for readers who cannot see a Makefile target. Both were caught by accident while looking at something else, which is not a process.

## What the check rejects

A title that reaches the user-facing changelog has to be backed by a change a user can observe, and has to be well-formed. Each of these fails it, and each has a test:

| Rejected | Why it would otherwise ship |
| --- | --- |
| `feat:` on a diff with nothing observable | The entry describes something no user can see. Observable means `src/` outside `src/test/`, or one of the packaged files: `package.json`, `icon.png`, `.vscodeignore`. |
| `Update README`, `wip: hack on the toggle` | `cliff.toml` ends with a catch-all `{ message = "^.*", skip = false }`, so an unrecognised type does not fall out of the changelog — it lands in **🔍 Other**. |
| `feat add setting`, `fixup! wip` | The parsers match on prefix, so this is filed under **✨ Features** anyway, and because the conventional parse then fails git-cliff prints the subject raw: the entry reads `- feat add setting`, type included. |
| `feature: add a setting`, `fixes: restore startup` | Same prefix matching, under a type this repository does not use. `gitlint` holds commit messages to that vocabulary and never sees a title. |
| `ci!: drop the release workflow` on an internal diff | `cliff.toml` sets `protect_breaking_commits`, which exempts a breaking change from a skipping parser, so the `!` pulls an internal type into the changelog. |

Nothing here is hardcoded. What reaches the changelog and whether a breaking marker overrides a skip come from `cliff.toml`; the accepted type vocabulary comes from `[contrib-title-conventional-commits]` in `.gitlint`, falling back to gitlint's own default when that section leaves it unset, as it does today.

The narrow scope is deliberate: this rejects titles that would reach the changelog, not every title. `cliff.toml` skips a bare `0.4.2` release subject by name, so a shape or vocabulary rule applied unconditionally would reject a release commit git-cliff never prints. There is a case pinning that.

## The check guards itself

A checker that stops checking is worse than no checker, because it produces a green mark that means nothing. Strip `commit_parsers` from `cliff.toml` and a naive implementation classifies every title as invisible and passes everything.

So the parse is asserted against known subjects — `feat:` and `fix:` must reach the changelog, `ci:`, `docs:`, `build(deps):` and `chore(deps-dev):` must not — and a configuration it cannot read **fails the run** with exit 2, kept distinct from a title problem's exit 1. That applies in three places: `commit_parsers` it cannot parse, a `protect_breaking_commits` value in a form it does not recognise, and an empty declared type list. Each failure message names both causes, parsing outgrown by a reformatted config or policy changed deliberately, because the remedy differs.

## Verification

`scripts/test-check-pr-title.sh`, wired into `make test` beside the two existing script tests, so `make check` covers it. It asserts, by category:

- Titles that belong in the changelog and are backed by `src/`, `package.json`, `icon.png` or `.vscodeignore` pass; the two historical mislabels fail.
- Types `cliff.toml` skips pass regardless of the diff, and a bare version subject passes because it is skipped by name.
- Malformed subjects, unknown types, and types outside the `.gitlint` vocabulary fail.
- Breaking markers on skipped types fail on an internal diff and pass when backed by `src/`.
- A rename is recognised by the path it came from, guarded by an assertion that the workflow still emits `previous_filename` — without that, the rename case could not occur in CI and would prove nothing.
- Degradation cases exit 2 rather than passing: `commit_parsers` removed, `feat` marked skipped, `protect_breaking_commits` in an unreadable form. Each is followed by an assertion that the config copy really was rewritten.

Every case was also run against the pre-fix script to confirm it failed then and passes now; a test that would have passed before the change is not evidence.

Tests run against a **copy** of `cliff.toml` in a temporary directory. The checker reads `cliff.toml` from the working directory, so a `cd` is enough to swap the config under it. That matters because the degradation cases need a broken config and `make check` is the pre-release gate — editing the real file in place would leave a window where an interrupted release run holds a mangled config. Verified that `cliff.toml` is untouched after a run.

Also runs on both `ubuntu-latest` and `macos-latest`, because the test edits config with `sed` and in-place behaviour differs between GNU and BSD. The test avoids `-i` for that reason, and the matrix is what keeps that honest.

## Notes on the workflow

`types` includes `edited`, because retitling is the remedy the check asks for and a check that does not re-run on a retitle cannot confirm the fix. That is also why it is a separate workflow rather than a job in `ci.yml` — adding `edited` there would re-run the entire test matrix whenever anyone touched a title or description.

The changed-file list is paginated, and emits both paths of a rename, matching the idiom `bot-automerge.yml` already uses. `gh pr view --json files` returns only the first 100 paths with no indication there are more: measured against a 115-file pull request, it returned 100 while the paginated call returned all 115. A truncated list produces a rejection whose stated reason is untrue, which is the one thing this check cannot afford.

The title reaches the script through `env:` rather than being interpolated into the shell. `cliff.toml`, `.gitlint` and the checker are read from the PR head, so a branch that changes changelog or vocabulary policy is judged by its own rules; the trade is that a branch could also neuter the check by editing those files, which is acceptable for a labelling guard whose edit would be sitting in the diff.

**This PR is titled `ci:` and is subject to its own check** — it touches only `.github/`, `scripts/` and `Makefile`, so a `feat:` title would fail it.

## Known limitations

- `package.json` is matched whole, so a diff touching only npm scripts or a devDependency range counts as observable. Narrowing it to the manifest keys users can see means reading the base revision, where failing open leaves the hole and failing closed adds a new way to block a pull request. Dependency and version bumps arrive under types `cliff.toml` skips, so they never reach the predicate.
- A `BREAKING CHANGE:` footer in a branch commit can make the squashed commit breaking while the title says nothing. `squash_merge_commit_message` is `COMMIT_MESSAGES` here, so those bodies do reach main; `gitlint` sees them, this check is handed only the title.
- Title style — case after the colon, length — stays with `gitlint` for commits. This check's remit is what reaches the changelog.

## Not included

Making this a required status check, which is a ruleset change rather than a code one.
