### PR TITLE
ci: standardize bot auto-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,18 @@ updates:
     groups:
       actions:
         patterns: ['*']
+    cooldown:
+      # Wider than the npm ecosystem above rather than at parity with it, and the
+      # asymmetry is the point. This is the one ecosystem whose packages execute
+      # with this repository's own token, inside jobs holding contents and
+      # pull-requests write, so a compromised release can be published and
+      # proposed here within hours. When the risk is the publisher rather than a
+      # changed interface, a patch is not safer than a major, so the delay covers
+      # every update and not only majors.
+      #
+      # This is also the soak period that bot-automerge.yml's actions-major branch
+      # leans on. That branch arms a major unless the diff reaches publish.yml or
+      # one of the two autoupdate crons, so most actions majors merge unattended;
+      # a delay between publication and proposal is what that relies on.
+      default-days: 7
+      semver-major-days: 30

--- a/.github/workflows/bot-automerge.yml
+++ b/.github/workflows/bot-automerge.yml
@@ -64,6 +64,69 @@ jobs:
       PR_URL: ${{ github.event.pull_request.html_url }}
     steps:
       # No checkout step: nothing below reads the repository.
+
+      # Optional, and inert unless both settings resolve. Arming under an App matters
+      # because auto-merge is completed by whoever armed it, and GitHub creates no workflow
+      # run for an event caused by `GITHUB_TOKEN` -- so a `GITHUB_TOKEN` merge fires no
+      # `push` and no `pull_request_target: closed` trigger downstream, while an App merge
+      # does. The note at the top of this file says nothing here depends on those triggers,
+      # and that stays true; this buys the option rather than a fix for a current break.
+      #
+      # Neither setting exists here yet, so this resolves false on every run and the whole
+      # App path is inert -- which is why it is written as a detection rather than a
+      # requirement. Note that a Dependabot-triggered run is handed the *Dependabot* secret
+      # store rather than the Actions one, so whenever these are added the private key has
+      # to go into both stores or the App path stays inert on exactly the pull requests it
+      # was added for. Saying so here is the point: the failure is otherwise entirely silent
+      # -- the token comes back empty and the fallback takes over with nothing logged.
+      - name: Detect App credentials
+        id: creds
+        env:
+          APP_ID_VALUE: ${{ vars.APP_ID }}
+          APP_KEY_VALUE: ${{ secrets.APP_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -n "$APP_ID_VALUE" ] && [ -n "$APP_KEY_VALUE" ]; then
+            echo "available=true" >>"$GITHUB_OUTPUT"
+          else
+            echo "available=false" >>"$GITHUB_OUTPUT"
+            echo "::notice::No App credential on this run; arming under the default" \
+                 "token. The merge will fire no downstream push or closed event."
+          fi
+
+      # `APP_ID` holds the App's numeric id, which is what `create-github-app-token` wants;
+      # the client id is the separate `Iv23li...` string and is not what goes here. The
+      # sibling repositories use the same two names, so a key rotation is one operation
+      # across all of them rather than several spellings to remember. It is a variable
+      # rather than a secret because `if:` can read `vars` and cannot read `secrets`, and
+      # that test is what keeps this path optional.
+      - name: Mint an App token, if one is configured
+        id: app-token
+        if: steps.creds.outputs.available == 'true'
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          # Without these the token inherits every permission the installation holds, which
+          # is more than this job declares for itself. Narrowing the borrowed identity to
+          # match the default one keeps the two carrying the same authority.
+          permission-contents: write
+          permission-pull-requests: write
+
+      # `continue-on-error` above means a failed mint does not stop the job, so it has to be
+      # reported here or it passes unnoticed. Worth knowing while reading a run: a
+      # `continue-on-error` step is recorded as `conclusion: success` by the jobs API even
+      # when its log carries a hard refusal, so this notice is the only honest signal short
+      # of opening the log.
+      - name: Report a mint that failed
+        if: >-
+          steps.creds.outputs.available == 'true' &&
+          (steps.app-token.outcome != 'success' || steps.app-token.outputs.token == '')
+        run: |
+          echo "::warning::App credentials are set but minting failed; falling back to" \
+               "the default token. Auto-merge still works; downstream triggers will not."
+
       - name: Fetch Dependabot metadata
         id: meta
         if: github.event.pull_request.user.login == 'dependabot[bot]'
@@ -245,6 +308,10 @@ jobs:
         if: steps.eligible.outputs.should_merge == 'true'
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          # Overrides the job-level GH_TOKEN when an App token was minted. This is the step
+          # whose identity decides the merge event's identity, so it is the only one where
+          # the borrowed token changes anything observable.
+          GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
         run: |
           # Read into a variable first, under `set -e`. Piping the query straight into
           # grep would treat a failed query as "label absent" -- grep sees no input,

--- a/.github/workflows/bot-automerge.yml
+++ b/.github/workflows/bot-automerge.yml
@@ -95,15 +95,27 @@ jobs:
           # Every commit must have been created by GitHub itself, and be the bot's own
           # unless it is a merge.
           #
-          # The signature is the load-bearing half. Author identity alone is not a guard:
-          # .author.login is resolved from the commit's author email, so anyone who can
-          # push can set it to dependabot's noreply address and be read as the bot. A
-          # commit created through GitHub -- by Dependabot, by pre-commit-ci, or by the
-          # Update branch button -- is signed by GitHub's key, and its signed payload names
-          # `committer GitHub <noreply@github.com>`. A collaborator cannot forge that
-          # without GitHub's private key, and the payload is inside the signature, so it
-          # cannot be edited either. A locally pushed commit is signed by the pusher's own
-          # key, or not at all.
+          # Author identity alone is not a guard: .author.login is resolved from the
+          # commit's author email, so anyone who can push can set it to dependabot's
+          # noreply address and be read as the bot.
+          #
+          # `.committer.login == "web-flow"` is the load-bearing half, and it is
+          # deliberately not the payload text. GitHub resolves that field from the signing
+          # key itself, so it is not metadata a pusher can set: measured on real pull
+          # requests across four repositories, both Dependabot and pre-commit-ci commits
+          # report `web-flow` with `verified: true` and `reason: valid`, while a human's
+          # own commits report that human's login.
+          #
+          # The payload test naming `committer GitHub <noreply@github.com>` stays as an
+          # independent second condition rather than as the argument. On its own it would
+          # rest on an unstated premise -- that GitHub declines to mark a commit verified
+          # when its committer email is not a verified email of the signing key's owner --
+          # and a guard should not rest on a premise its reader cannot check. A review on
+          # a sibling repository read that earlier form as spoofable, which was half right:
+          # the specific bypass most likely fails, but the check was keyed on the wrong
+          # field. Requiring both means the guard holds either way. A locally pushed commit
+          # is signed by the pusher's own key, or not at all, and neither comes back as
+          # `web-flow`.
           #
           # Merges are exempt from the author check but not from the signature check, and
           # that pairing is what makes the exemption safe. A merge commit's tree is not
@@ -121,6 +133,8 @@ jobs:
           set -euo pipefail
           jq_rows='.[] | [
             (if (.commit.verification.verified == true)
+                and (.commit.verification.reason == "valid")
+                and ((.committer.login // "") == "web-flow")
                 and ((.commit.verification.payload // "") | split("\n")
                      | any(startswith("committer GitHub <noreply@github.com>")))
              then "github" else "elsewhere" end),


### PR DESCRIPTION
## Summary

Closes the last two gaps between this repository's `bot-automerge.yml` and the shape the siblings now share, and adds the actions cooldown that was missing. This file was the strongest of the set and is where most of the shared shape came from — the guard structure, the `user.login` author test, the live kill-switch re-read, the ecosystem-gated majors and the refusal to poll checks in-workflow all propagated outward from here. So the diff is small by design: 105 insertions against 392 in the repository that needed the most work.

The actions ecosystem had **no cooldown at all** while npm had thirty days on majors, which is backwards. This is the one ecosystem whose packages execute with this repository's own token, inside jobs holding contents and pull-requests write, so a compromised release can be published and proposed here within hours. When the risk is the publisher rather than a changed interface, a patch is not safer than a major, so the delay covers every update. It is also the soak period the actions-major branch already leaned on without having: that branch arms a major unless the diff reaches `publish.yml` or one of the two autoupdate crons, so most actions majors merge unattended, and a delay between publication and proposal is what makes that defensible.

The provenance gate is tightened in response to a review on a sibling repository carrying the same check, which read it as spoofable. That was half right and worth acting on precisely. The gate keyed on the signed payload's `committer GitHub <noreply@github.com>` line, and committer name and email are git metadata the pusher controls — so it keyed on the wrong field. The specific bypass most likely fails anyway, because GitHub declines to mark a commit verified when the committer email is not a verified email of the signing key's owner. But that is a premise a reader cannot check from the file, and a security guard should not rest on one. It now also requires `.committer.login == "web-flow"`, which GitHub resolves from the signing key itself, keeping the payload test as an independent second condition.

The App wiring is added last and is inert: neither setting exists here, so arming falls back to the default token exactly as it does today. It buys the option on downstream events rather than repairing a current break — the note at the top of this file already records that nothing here depends on them.

## Test plan

- [x] `pre-commit run --files` passes on both changed files, including `Validate Dependabot Config (v2)`, `Validate GitHub Workflows` and `Lint GitHub Actions workflow files`
- [x] `actionlint` clean, which covers the embedded `shellcheck` pass on every `run:` block; `yamllint` clean
- [x] The `web-flow` discriminator was measured before the change, not after: across four repositories, Dependabot and pre-commit-ci commits both report `committer.login=web-flow`, `verified=true`, `reason=valid`, while a human's own commits report that human's login. Both bot authors survive the tightened gate
- [x] All three commits carry a verified signature
- [ ] CI is green — pending on this head
- [ ] A live bot-triggered run. Not verifiable before merge; the next Dependabot or pre-commit-ci pull request is the check to watch.

## Reviewer guide

- **Effort:** ~10 minutes. Three commits, each one concern, each readable on its own.
- **Read only these:** the `jq_rows` classification in `Decide eligibility`, and the `cooldown` block in `dependabot.yml`. The third commit is additive and inert.
- **Already covered, please skip:** linting, schema validation, signatures, and the empirical check that both bots still pass the tightened gate.
- **The calls only you can make:** whether `default-days: 7` on actions is the right delay given that most actions majors here now merge unattended. Seven days is a guess calibrated to "long enough that a compromised release is usually reported", not to anything measured about this repository. Tightening it costs freshness; loosening it costs soak.
- **Known weaknesses:** `web-flow` is an implementation detail of how GitHub attributes commits it signs — stable and observable across four repositories today, but not a documented contract, so it could change without notice. The payload condition is the hedge, which is a second reason it stays rather than being replaced. Separately, the actions-major hold list in this file names `publish.yml`, `changelog-autoupdate.yml` and `pre-commit-autoupdate.yml` explicitly; that list is correct against today's triggers and fails by *arming* if a trigger changes without it being re-derived. That was already true before this pull request and is not made worse by it.

## Notes

The three commits are ordered so each leaves a working tree, and the cooldown lands before the policy that leans on it. The second and third were briefly one commit whose message described only the provenance change; they were split so each message describes what is actually in it.

<details>
<summary>Files touched</summary>

Status legend: `+` added, `~` modified, `-` removed, `→` renamed, `~/→` renamed and modified.

| status | path | role |
|--|--|--|
| `~` | [.github/dependabot.yml](https://github.com/michen00/invisible-squiggles/blob/ci/standardize-bot-automerge/.github/dependabot.yml) | adds the actions cooldown that was absent entirely — 7 days on every update, 30 on majors — which is the soak the actions-major branch relies on |
| `~` | [.github/workflows/bot-automerge.yml](https://github.com/michen00/invisible-squiggles/blob/ci/standardize-bot-automerge/.github/workflows/bot-automerge.yml) | pins the provenance gate to the web-flow committer and a valid reason, and offers the optional App identity to the arming step |

</details>
