### PR TITLE
docs: fix the status bar label and listing links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,9 @@ help: ## Show this help message
 ## Build and install ##
 #######################
 
-# Common logic for preparing README for marketplace (strip untrusted SVG badges and Documentation section)
+# Common logic for preparing README for marketplace: strip untrusted SVG badges and the
+# repository-only Documentation section, make every remaining link absolute, and refuse
+# to package a listing that points at anything its reader could not reach.
 define PREPARE_DOCS
 	set -e; \
     trap 'for f in README.md CHANGELOG.md; do [ -f "$$f.bak" ] && mv "$$f.bak" "$$f"; done' EXIT; \

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The **Invisible Squiggles** VSCode extension allows you to **selectively toggle 
 
 - ✅ **Toggle squiggles on/off globally or by type** from the **status bar** or **command palette**
 - ✅ **Independently control hint, info, warning, and error squiggles**
-- ✅ When squiggles are hidden, problem icons in the Problems panel are also made less visible for a fully distraction-free experience.
+- ✅ **The Problems panel follows along** — its icons take their color from the editor's diagnostic colors, so hiding squiggles fades them too
 
 ![demo](https://github.com/user-attachments/assets/50bce932-ee6a-4422-88d1-a500b81eac57)
 
@@ -29,7 +29,7 @@ The **Invisible Squiggles** VSCode extension allows you to **selectively toggle 
 
 ### Why not use the built-in "Problems: Visibility" setting?
 
-VS Code's [built-in setting](https://code.visualstudio.com/updates/v1_85#_hide-problem-decorations) (`problems.visibility`) hides all problem decorations when turned off—but it always shows a **warning in the status bar** while they’re hidden. Invisible Squiggles gives you:
+VS Code's [built-in setting](https://code.visualstudio.com/updates/v1_85#_hide-problem-decorations) (`problems.visibility`) hides all problem decorations when turned off — but it always shows a **warning in the status bar** while they're hidden. Invisible Squiggles gives you:
 
 - **No forced status bar clutter** — The status bar indicator is optional and can be disabled.
 - **Choose subsets** — Hide only errors, only warnings, only info, only hints, or any combination. The built-in option is all-or-nothing.
@@ -43,7 +43,7 @@ VS Code's [built-in setting](https://code.visualstudio.com/updates/v1_85#_hide-p
 
 ### **Option 1: Using the Status Bar Button**
 
-Click the **👁️ Toggle Squiggles** button at the **bottom right**.
+Click **Squiggles:** at the **bottom right**. The eye beside it shows the current state — open while squiggles are visible, closed while they are hidden.
 
 ### **Option 2: Using the Command Palette**
 
@@ -80,11 +80,11 @@ Everything lives under `invisibleSquiggles` and applies globally.
 
 The four `hide*` settings choose which squiggle types the toggle acts on — this is the "independently control" part. Set `hideErrors` to `false` and errors stay visible while warnings, info, and hints disappear. Turn all four off and the toggle has nothing to act on.
 
-## ⚠️ Important Notes
+## 🔹 Important Notes
 
 - **Manual edits will be overwritten**: When squiggles are hidden, the extension stores your original color customizations and applies transparent colors. Toggling squiggles will overwrite any manual changes you make to these colors while they're hidden.
 - **Customizations stored in settings**: Your original color customizations are saved in VS Code's `settings.json`. If this file becomes corrupted, your saved customizations may be lost.
-- Users who upgrade while squiggles are hidden may need to toggle twice to reset state.
+- **Upgrading while hidden**: you may need to toggle twice to reset the state.
 
 ## 🔹 Documentation [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/michen00/invisible-squiggles)
 

--- a/scripts/prepare-readme.sh
+++ b/scripts/prepare-readme.sh
@@ -110,7 +110,9 @@ sed -e '/zenodo\.org.*\.svg/d' -e '/## .*Documentation/,$d' "$in" |
 # bracket expression, so [ \t] is space, backslash and the letter t. BSD grep reads it that
 # way -- it misses a tab and matches a stray t -- while the ugrep some machines alias to
 # grep honours the escape, so a local run agrees with the intent and CI does not.
-bracketed=$(grep -E '\]\([[:blank:]]*<|^[[:blank:]]{0,3}\[[^]]+\]:[[:blank:]]*<' "$stripped" || true)
+# The indent allowance is spaces only, for the reason given at the leftover scan below:
+# a leading tab makes the line an indented code block rather than a definition.
+bracketed=$(grep -E '\]\([[:blank:]]*<|^ {0,3}\[[^]]+\]:[[:blank:]]*<' "$stripped" || true)
 if [ -n "$bracketed" ]; then
   echo "Error: $SCRIPT_NAME: angle-bracketed link destinations are not supported:" >&2
   printf '%s\n' "$bracketed" | sed 's/^/  /' >&2
@@ -236,7 +238,11 @@ leftover=$(
     # growing what is rewritten is what produced the regressions in this branch. So an
     # indented relative definition stops the build rather than being rewritten, and an
     # indented absolute one passes untouched, which is every case this repository has.
-    while (/^[ \t]{0,3}\[[^\]]+\]:[ \t]*(\S+)/gm) {
+    #
+    # Spaces only, not [ \t]. A leading tab is a four-column tab stop, so a line starting
+    # with one is an indented code block and not a definition at all; counting it as one
+    # unit of indent made a tab-indented code example refuse the whole listing.
+    while (/^ {0,3}\[[^\]]+\]:[ \t]*(\S+)/gm) {
       print "$1\n" unless $1 =~ m{^(?:\w+:|//|\#)};
     }
   ' "$out" | sort -u

--- a/scripts/prepare-readme.sh
+++ b/scripts/prepare-readme.sh
@@ -99,6 +99,20 @@ trap cleanup EXIT
 sed -e '/zenodo\.org.*\.svg/d' -e '/## .*Documentation/,$d' "$in" |
   perl -0777 -pe 's/\s+$/\n/' > "$stripped"
 
+# Markdown allows a destination to be wrapped in angle brackets, and nothing below reads
+# that shape. Refusing it by name is the contract in one rule: a form the rewrite does not
+# understand stops the build with an instruction, rather than being taught to the rewrite
+# one shape at a time. Teaching it was tried -- the bracket then had to be stripped in
+# every place that inspects a destination, and the place that was missed let an anchor
+# into the removed section ship. Checked against the stripped text so brackets in the part
+# that never reaches the listing do not refuse a README that is fine.
+bracketed=$(grep -E '\]\([ \t]*<|^\[[^]]+\]:[ \t]*<' "$stripped" || true)
+if [ -n "$bracketed" ]; then
+  echo "Error: $SCRIPT_NAME: angle-bracketed link destinations are not supported:" >&2
+  printf '%s\n' "$bracketed" | sed 's/^/  /' >&2
+  die "write the destination plainly, without < >"
+fi
+
 # Images resolve through /raw/ and links through /blob/ -- the same split vsce draws
 # between baseImagesUrl and baseContentUrl. A blob URL serves an HTML page, so an image
 # pointed at one renders as a broken image rather than a picture.
@@ -111,9 +125,6 @@ LINK_BASE="$repo_url/blob/$REPO_REF/" \
     }
     sub absolute {
       my ($target) = @_;
-      # <https://example.com> is a legal destination and is absolute; without stripping
-      # the bracket it reads as relative and gets a GitHub base bolted onto a full URL.
-      $target =~ s/^<//;
       return $target =~ m{^(?:\w+:|//|\#)};
     }
     # An optional link title after the destination. \x27 is a single quote, spelled that
@@ -199,8 +210,12 @@ fi
 # Belt and braces: whatever the rules above did or skipped, nothing relative may ship.
 # This scan is deliberately broader than the rewrite: it takes everything up to the
 # closing paren and inspects the first token, so a form the rewrite cannot handle -- a
-# title shape it does not know, an angle-bracketed destination -- fails the build loudly
-# instead of slipping through as a relative link. Wider here, narrower there, on purpose.
+# title shape it does not know, for instance -- fails the build loudly instead of slipping
+# through as a relative link. Wider here, narrower there, on purpose.
+#
+# It normalises nothing, deliberately. Stripping angle brackets here would make `<#x>`
+# read as an anchor and pass, which is the same assumption the check above already makes;
+# a second barrier that shares the first one's blind spot is not a second barrier.
 leftover=$(
   perl -0777 -ne '
     while (/\]\(([^)]*)\)/g) {
@@ -208,17 +223,12 @@ leftover=$(
       $inside =~ s/^[ \t]+//;
       my ($target) = $inside =~ /^(\S+)/;
       next unless defined $target;
-      $target =~ s/^<//;
-      $target =~ s/>$//;
       print "$target\n" unless $target =~ m{^(?:\w+:|//|\#)};
     }
     # Only the destination token is inspected, whatever follows it, so this stays broader
     # than the rewrite for definitions the way it already is for inline links.
     while (/^\[[^\]]+\]:[ \t]*(\S+)/gm) {
-      my $target = $1;
-      $target =~ s/^<//;
-      $target =~ s/>$//;
-      print "$target\n" unless $target =~ m{^(?:\w+:|//|\#)};
+      print "$1\n" unless $1 =~ m{^(?:\w+:|//|\#)};
     }
   ' "$out" | sort -u
 )

--- a/scripts/prepare-readme.sh
+++ b/scripts/prepare-readme.sh
@@ -126,6 +126,13 @@ LINK_BASE="$repo_url/blob/$REPO_REF/" \
     while (/!\[([^\]]+)\](?![\[\(])/g)      { $image_label{lc $1} = 1 }
     while (/(?<!!)\[[^\]]*\]\[([^\]]+)\]/g) { $link_label{lc $1} = 1 }
     while (/(?<!!)\[([^\]]*)\]\[\]/g)       { $link_label{lc $1} = 1 }
+    # The shortcut link [label], the mirror of the image case above. Every exclusion
+    # here was earned: `!` before it is an image, `]` before it is the second half of a
+    # full reference which the rules above already classified (counting it here made
+    # ![alt][label] register as a link and collide with itself), `[` or `(` after it is
+    # some other form, and `:` after it is the definition line, which must not count as
+    # a use of its own label.
+    while (/(?<![!\]])\[([^\]]+)\](?![\[\(:])/g) { $link_label{lc $1} = 1 }
     # An optional link title after the destination. \x27 is a single quote, spelled that
     # way because this whole program is inside a single-quoted shell string.
     my $title = qr{(?:[ \t]+(?:"[^"]*"|\x27[^\x27]*\x27|\([^()]*\)))?};

--- a/scripts/prepare-readme.sh
+++ b/scripts/prepare-readme.sh
@@ -91,9 +91,8 @@ esac
 
 stripped=$(mktemp)
 targets=$(mktemp)
-conflicts=$(mktemp)
 cleanup() {
-  rm -f "$stripped" "$targets" "$conflicts"
+  rm -f "$stripped" "$targets"
 }
 trap cleanup EXIT
 
@@ -106,43 +105,13 @@ sed -e '/zenodo\.org.*\.svg/d' -e '/## .*Documentation/,$d' "$in" |
 LINK_BASE="$repo_url/blob/$REPO_REF/" \
   IMG_BASE="$repo_url/raw/$REPO_REF/" \
   TARGETS="$targets" \
-  CONFLICTS="$conflicts" \
   perl -0777 -pe '
     BEGIN {
       open($fh, ">", $ENV{TARGETS}) or die "cannot record link targets: $!";
-      open($cfh, ">", $ENV{CONFLICTS}) or die "cannot record label conflicts: $!";
     }
     sub absolute {
       my ($target) = @_;
       return $target =~ m{^(?:\w+:|//|\#)};
-    }
-    # Which reference labels are used by images, so `[label]: path` can pick the same
-    # base an inline image would get. Labels are case-insensitive in Markdown. Both the
-    # full form ![alt][label] and the collapsed ![label][] count.
-    # Detection runs over a copy with code removed. A bracket inside a code span or a
-    # fenced block is prose about Markdown, not Markdown, and counting it can only
-    # produce a false conflict -- which refuses to package a README that is entirely
-    # correct. The copy is scanned; the document itself is untouched.
-    my $scan = $_;
-    $scan =~ s/^```.*?^```//gms;
-    $scan =~ s/`[^`\n]*`//g;
-    my (%image_label, %link_label);
-    while ($scan =~ /!\[[^\]]*\]\[([^\]]+)\]/g)      { $image_label{lc $1} = 1 }
-    while ($scan =~ /!\[([^\]]*)\]\[\]/g)            { $image_label{lc $1} = 1 }
-    # The shortcut form ![label], with no second bracket pair and no parenthesis after.
-    while ($scan =~ /!\[([^\]]+)\](?![\[\(])/g)      { $image_label{lc $1} = 1 }
-    while ($scan =~ /(?<!!)\[[^\]]*\]\[([^\]]+)\]/g) { $link_label{lc $1} = 1 }
-    while ($scan =~ /(?<!!)\[([^\]]*)\]\[\]/g)       { $link_label{lc $1} = 1 }
-    # The shortcut link [label], the mirror of the image case above. Every exclusion
-    # here was earned: `!` before it is an image, `]` before it is the second half of a
-    # full reference which the rules above already classified (counting it here made
-    # ![alt][label] register as a link and collide with itself), `[` or `(` after it is
-    # some other form, and `:` after it is the definition line, which must not count as
-    # a use of its own label. The second lookbehind drops task list markers: `- [x]` is
-    # a checkbox, and treating it as a reference to a label named x would refuse any
-    # README that has both a task list and an image reference sharing that label.
-    while ($scan =~ /(?<![!\]])(?<![-*+] )\[([^\]]+)\](?![\[\(:])/g) {
-      $link_label{lc $1} = 1;
     }
     # An optional link title after the destination. \x27 is a single quote, spelled that
     # way because this whole program is inside a single-quoted shell string.
@@ -155,38 +124,24 @@ LINK_BASE="$repo_url/blob/$REPO_REF/" \
     s{(\]\([ \t]*)([^)\s]+)($title[ \t]*\))}{
       absolute($2) ? "$1$2$3" : do { print $fh "$2\n"; "$1$ENV{LINK_BASE}$2$3" }
     }ge;
-    # [label]: path -- the base depends on how the label is used, not on the definition,
-    # because a definition consumed by ![alt][label] is an image and needs /raw/ too.
-    s{^(\[([^\]]+)\]:[ \t]*)(\S+)[ \t]*$}{
-      my ($prefix, $label, $target) = ($1, $2, $3);
-      my $key = lc $label;
+    # [label]: path -- a definition carries no `!` to say whether it feeds an image or a
+    # link, so the base comes from what the target *is* rather than from how the label is
+    # used. Reading usage means classifying every bracket in the document, and brackets
+    # appear in task lists, code spans and fenced examples; three separate false
+    # conflicts came out of trying, each one refusing to package a correct README. The
+    # file extension is a property of the target alone and needs no document scan.
+    s{^(\[[^\]]+\]:[ \t]*)(\S+)[ \t]*$}{
+      my ($prefix, $target) = ($1, $2);
       if (absolute($target)) {
         "$prefix$target";
       } else {
         print $fh "$target\n";
-        if ($image_label{$key} && $link_label{$key}) {
-          # One definition cannot be both an HTML page and raw bytes. Left relative so
-          # the leftover scan also refuses it, and reported by label below.
-          print $cfh "$label\n";
-          "$prefix$target";
-        } else {
-          my $base = $image_label{$key} ? $ENV{IMG_BASE} : $ENV{LINK_BASE};
-          "$prefix$base$target";
-        }
+        my $is_image = $target =~ /\.(?:png|jpe?g|gif|svg|webp|avif|bmp|ico)$/i;
+        "$prefix" . ($is_image ? $ENV{IMG_BASE} : $ENV{LINK_BASE}) . $target;
       }
     }gme;
-    END { close($fh); close($cfh) }
+    END { close($fh) }
   ' "$stripped" > "$out"
-
-# A label used by both an image and a link has no single correct base: /raw/ serves the
-# bytes an image needs and /blob/ serves the page a link needs. Rather than guess and
-# break one of them, name the label and stop.
-if [ -s "$conflicts" ]; then
-  echo "Error: $SCRIPT_NAME: these reference labels are used by both an image and a" >&2
-  echo "  link, so no single base is right for them:" >&2
-  sort -u "$conflicts" | sed 's/^/    /' >&2
-  die "give the image and the link separate labels"
-fi
 
 # A rewritten link is only useful if the file is really there; an absolute URL to a
 # missing path is a 404 on the listing instead of a visibly broken relative link.

--- a/scripts/prepare-readme.sh
+++ b/scripts/prepare-readme.sh
@@ -1,23 +1,55 @@
 #!/usr/bin/env bash
+
+# Prepare README.md for the marketplace listings.
+#
+# Three things happen here, and only the first is cosmetic:
+#
+#   1. The zenodo badge is dropped, because vsce rejects SVGs from badge providers it
+#      does not trust, and the Documentation section goes along with everything after
+#      it, because that section is a repository index -- nobody reading a marketplace
+#      page can follow it.
+#   2. Every remaining relative link is rewritten to an absolute GitHub URL. vsce does
+#      this too, inferring a base from package.json's `repository` field, but a listing
+#      that leans on that inference breaks quietly when the field changes shape: a
+#      relative link on a marketplace page resolves against the marketplace, not
+#      against GitHub. Doing it here makes the result explicit, testable, and the same
+#      on Open VSX.
+#   3. The output is then checked for anything unreachable -- a relative link that
+#      survived, a link to a file that is not in the repository, or an anchor pointing
+#      into the section step 1 just removed. That last one is damage this transform
+#      causes rather than finds, which is the reason it checks.
+
 set -euo pipefail
 
 SCRIPT_NAME=$(basename "$0")
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 usage() {
   cat << EOF
 Usage: $SCRIPT_NAME <input-file> <output-file>
 
-Strips zenodo badge and Documentation section from a README, normalizes trailing newline.
+Strips the zenodo badge and the Documentation section from a README, rewrites relative
+links to absolute GitHub URLs, and refuses to write a listing that points at anything a
+reader of that listing could not reach.
 
 Arguments:
   <input-file>   Path to the input README.md
   <output-file>  Path to write the processed README.md
+
+Environment:
+  REPO_URL       Repository URL for absolute links (default: package.json repository)
+  REPO_REF       Ref those links point at (default: main)
 
 Examples:
   $SCRIPT_NAME README.md.bak README.md
   $SCRIPT_NAME test-workspace/README.md /tmp/README.out.md
 EOF
   exit "${1:-0}"
+}
+
+die() {
+  echo "Error: $SCRIPT_NAME: $*" >&2
+  exit 1
 }
 
 if [ "$#" -ne 2 ]; then
@@ -28,8 +60,133 @@ in="$1"
 out="$2"
 
 if [ ! -f "$in" ]; then
-  echo "Error: Input file not found: $in" >&2
-  exit 1
+  die "input file not found: $in"
 fi
 
-sed -e '/zenodo\.org.*\.svg/d' -e '/## .*Documentation/,$d' "$in" | perl -0777 -pe 's/\s+$/\n/' > "$out"
+REPO_REF="${REPO_REF:-main}"
+
+# Read the same field vsce reads, so the two agree on where a relative link points --
+# and so its absence stops the build here instead of silently shipping relative links.
+repo_url="${REPO_URL:-$(
+  node -e '
+    const pkg = require(process.argv[1]);
+    const repo = pkg.repository;
+    const url = typeof repo === "string" ? repo : ((repo && repo.url) || "");
+    process.stdout.write(String(url));
+  ' "$REPO_ROOT/package.json" 2> /dev/null || true
+)}"
+
+repo_url="${repo_url#git+}"
+repo_url="${repo_url%.git}"
+repo_url="${repo_url%/}"
+
+case "$repo_url" in
+  https://*) ;;
+  *)
+    die "no https repository URL available (got '$repo_url'). vsce derives the base for
+relative links from package.json's repository field; without it the listing would ship
+links that resolve against the marketplace rather than GitHub. Set REPO_URL to override."
+    ;;
+esac
+
+stripped=$(mktemp)
+targets=$(mktemp)
+cleanup() {
+  rm -f "$stripped" "$targets"
+}
+trap cleanup EXIT
+
+sed -e '/zenodo\.org.*\.svg/d' -e '/## .*Documentation/,$d' "$in" |
+  perl -0777 -pe 's/\s+$/\n/' > "$stripped"
+
+# Images resolve through /raw/ and links through /blob/ -- the same split vsce draws
+# between baseImagesUrl and baseContentUrl. A blob URL serves an HTML page, so an image
+# pointed at one renders as a broken image rather than a picture.
+LINK_BASE="$repo_url/blob/$REPO_REF/" \
+  IMG_BASE="$repo_url/raw/$REPO_REF/" \
+  TARGETS="$targets" \
+  perl -0777 -pe '
+    BEGIN {
+      open($fh, ">", $ENV{TARGETS}) or die "cannot record link targets: $!";
+    }
+    sub absolute {
+      my ($target) = @_;
+      return $target =~ m{^(?:\w+:|//|\#)};
+    }
+    # ![alt](path)
+    s{(!\[[^\]]*\]\()([^)\s]+)(\))}{
+      absolute($2) ? "$1$2$3" : do { print $fh "$2\n"; "$1$ENV{IMG_BASE}$2$3" }
+    }ge;
+    # [text](path)
+    s{(\]\()([^)\s]+)(\))}{
+      absolute($2) ? "$1$2$3" : do { print $fh "$2\n"; "$1$ENV{LINK_BASE}$2$3" }
+    }ge;
+    # [label]: path
+    s{^(\[[^\]]+\]:[ \t]*)(\S+)[ \t]*$}{
+      absolute($2) ? "$1$2" : do { print $fh "$2\n"; "$1$ENV{LINK_BASE}$2" }
+    }gme;
+    END { close($fh) }
+  ' "$stripped" > "$out"
+
+# A rewritten link is only useful if the file is really there; an absolute URL to a
+# missing path is a 404 on the listing instead of a visibly broken relative link.
+missing=0
+while IFS= read -r target; do
+  [ -n "$target" ] || continue
+  path="${target%%\#*}"
+  [ -n "$path" ] || continue
+  if [ ! -e "$REPO_ROOT/$path" ]; then
+    echo "Error: $SCRIPT_NAME: links '$path', which is not in the repository" >&2
+    missing=1
+  fi
+done < <(sort -u "$targets")
+if [ "$missing" -ne 0 ]; then
+  die "the listing would link files that do not exist"
+fi
+
+# Anchors that survive have to point at a heading that also survived. Cutting the
+# Documentation section is precisely what orphans one, so this checks the cut.
+dangling=$(
+  # -CSD decodes as UTF-8. Without it perl compares bytes, and a stray byte of a
+  # multi-byte character counts as alphanumeric -- an emoji heading then slugs to
+  # something no anchor could ever match, and every anchor looks dangling.
+  perl -CSD -0777 -ne '
+    my %slug;
+    while (/^\#{1,6}[ \t]+(.+?)[ \t]*$/gm) {
+      my $text = $1;
+      $text =~ s/\[([^\]]*)\]\([^)]*\)/$1/g;
+      $text =~ s/[^\p{Alnum} _-]//g;
+      $text = lc $text;
+      $text =~ s/ /-/g;
+      $slug{$text} = 1;
+    }
+    my %seen;
+    while (/\]\(\#([^)]+)\)/g) {
+      my $anchor = lc $1;
+      next if $seen{$anchor}++;
+      print "$anchor\n" unless $slug{$anchor};
+    }
+  ' "$out"
+)
+if [ -n "$dangling" ]; then
+  echo "Error: $SCRIPT_NAME: anchors point at headings the listing does not contain:" >&2
+  printf '%s\n' "$dangling" | sed 's/^/  #/' >&2
+  die "the Documentation section and everything below it is stripped, so an anchor into it cannot resolve"
+fi
+
+# Belt and braces: whatever the rules above did or skipped, nothing relative may ship.
+leftover=$(
+  perl -0777 -ne '
+    while (/\]\(([^)\s]+)\)/g) {
+      print "$1\n" unless $1 =~ m{^(?:\w+:|//|\#)};
+    }
+    while (/^\[[^\]]+\]:[ \t]*(\S+)[ \t]*$/gm) {
+      print "$1\n" unless $1 =~ m{^(?:\w+:|//|\#)};
+    }
+  ' "$out" | sort -u
+)
+if [ -n "$leftover" ]; then
+  echo "Error: $SCRIPT_NAME: relative links survived into the listing:" >&2
+  printf '%s\n' "$leftover" | sed 's/^/  /' >&2
+  die "a relative link on a marketplace page resolves against the marketplace"
+fi

--- a/scripts/prepare-readme.sh
+++ b/scripts/prepare-readme.sh
@@ -111,6 +111,9 @@ LINK_BASE="$repo_url/blob/$REPO_REF/" \
     }
     sub absolute {
       my ($target) = @_;
+      # <https://example.com> is a legal destination and is absolute; without stripping
+      # the bracket it reads as relative and gets a GitHub base bolted onto a full URL.
+      $target =~ s/^<//;
       return $target =~ m{^(?:\w+:|//|\#)};
     }
     # An optional link title after the destination. \x27 is a single quote, spelled that
@@ -137,7 +140,9 @@ LINK_BASE="$repo_url/blob/$REPO_REF/" \
         "$prefix$target$suffix";
       } else {
         print $fh "$target\n";
-        my $is_image = $target =~ /\.(?:png|jpe?g|gif|svg|webp|avif|bmp|ico)$/i;
+        # A query or fragment may follow the extension -- icon.png?raw=1 is still a png.
+        my $is_image =
+          $target =~ /\.(?:png|jpe?g|gif|svg|webp|avif|bmp|ico)(?:[?\#]\S*)?$/i;
         "$prefix" . ($is_image ? $ENV{IMG_BASE} : $ENV{LINK_BASE}) . "$target$suffix";
       }
     }gme;
@@ -149,7 +154,8 @@ LINK_BASE="$repo_url/blob/$REPO_REF/" \
 missing=0
 while IFS= read -r target; do
   [ -n "$target" ] || continue
-  path="${target%%\#*}"
+  # A fragment or a query is addressing, not path: icon.png?raw=1 is the file icon.png.
+  path="${target%%[?#]*}"
   [ -n "$path" ] || continue
   if [ ! -e "$REPO_ROOT/$path" ]; then
     echo "Error: $SCRIPT_NAME: links '$path', which is not in the repository" >&2
@@ -209,7 +215,10 @@ leftover=$(
     # Only the destination token is inspected, whatever follows it, so this stays broader
     # than the rewrite for definitions the way it already is for inline links.
     while (/^\[[^\]]+\]:[ \t]*(\S+)/gm) {
-      print "$1\n" unless $1 =~ m{^(?:\w+:|//|\#)};
+      my $target = $1;
+      $target =~ s/^<//;
+      $target =~ s/>$//;
+      print "$target\n" unless $target =~ m{^(?:\w+:|//|\#)};
     }
   ' "$out" | sort -u
 )

--- a/scripts/prepare-readme.sh
+++ b/scripts/prepare-readme.sh
@@ -122,6 +122,8 @@ LINK_BASE="$repo_url/blob/$REPO_REF/" \
     my (%image_label, %link_label);
     while (/!\[[^\]]*\]\[([^\]]+)\]/g)      { $image_label{lc $1} = 1 }
     while (/!\[([^\]]*)\]\[\]/g)            { $image_label{lc $1} = 1 }
+    # The shortcut form ![label], with no second bracket pair and no parenthesis after.
+    while (/!\[([^\]]+)\](?![\[\(])/g)      { $image_label{lc $1} = 1 }
     while (/(?<!!)\[[^\]]*\]\[([^\]]+)\]/g) { $link_label{lc $1} = 1 }
     while (/(?<!!)\[([^\]]*)\]\[\]/g)       { $link_label{lc $1} = 1 }
     # An optional link title after the destination. \x27 is a single quote, spelled that

--- a/scripts/prepare-readme.sh
+++ b/scripts/prepare-readme.sh
@@ -106,7 +106,11 @@ sed -e '/zenodo\.org.*\.svg/d' -e '/## .*Documentation/,$d' "$in" |
 # every place that inspects a destination, and the place that was missed let an anchor
 # into the removed section ship. Checked against the stripped text so brackets in the part
 # that never reaches the listing do not refuse a README that is fine.
-bracketed=$(grep -E '\]\([ \t]*<|^\[[^]]+\]:[ \t]*<' "$stripped" || true)
+# [[:blank:]] rather than [ \t]: POSIX drops the special meaning of a backslash inside a
+# bracket expression, so [ \t] is space, backslash and the letter t. BSD grep reads it that
+# way -- it misses a tab and matches a stray t -- while the ugrep some machines alias to
+# grep honours the escape, so a local run agrees with the intent and CI does not.
+bracketed=$(grep -E '\]\([[:blank:]]*<|^[[:blank:]]{0,3}\[[^]]+\]:[[:blank:]]*<' "$stripped" || true)
 if [ -n "$bracketed" ]; then
   echo "Error: $SCRIPT_NAME: angle-bracketed link destinations are not supported:" >&2
   printf '%s\n' "$bracketed" | sed 's/^/  /' >&2
@@ -226,8 +230,13 @@ leftover=$(
       print "$target\n" unless $target =~ m{^(?:\w+:|//|\#)};
     }
     # Only the destination token is inspected, whatever follows it, so this stays broader
-    # than the rewrite for definitions the way it already is for inline links.
-    while (/^\[[^\]]+\]:[ \t]*(\S+)/gm) {
+    # than the rewrite for definitions the way it already is for inline links. It also
+    # allows the indent Markdown allows -- up to three spaces, four being a code block --
+    # which the rewrite above deliberately does not. Growing what is refused is safe;
+    # growing what is rewritten is what produced the regressions in this branch. So an
+    # indented relative definition stops the build rather than being rewritten, and an
+    # indented absolute one passes untouched, which is every case this repository has.
+    while (/^[ \t]{0,3}\[[^\]]+\]:[ \t]*(\S+)/gm) {
       print "$1\n" unless $1 =~ m{^(?:\w+:|//|\#)};
     }
   ' "$out" | sort -u

--- a/scripts/prepare-readme.sh
+++ b/scripts/prepare-readme.sh
@@ -91,8 +91,9 @@ esac
 
 stripped=$(mktemp)
 targets=$(mktemp)
+conflicts=$(mktemp)
 cleanup() {
-  rm -f "$stripped" "$targets"
+  rm -f "$stripped" "$targets" "$conflicts"
 }
 trap cleanup EXIT
 
@@ -105,14 +106,24 @@ sed -e '/zenodo\.org.*\.svg/d' -e '/## .*Documentation/,$d' "$in" |
 LINK_BASE="$repo_url/blob/$REPO_REF/" \
   IMG_BASE="$repo_url/raw/$REPO_REF/" \
   TARGETS="$targets" \
+  CONFLICTS="$conflicts" \
   perl -0777 -pe '
     BEGIN {
       open($fh, ">", $ENV{TARGETS}) or die "cannot record link targets: $!";
+      open($cfh, ">", $ENV{CONFLICTS}) or die "cannot record label conflicts: $!";
     }
     sub absolute {
       my ($target) = @_;
       return $target =~ m{^(?:\w+:|//|\#)};
     }
+    # Which reference labels are used by images, so `[label]: path` can pick the same
+    # base an inline image would get. Labels are case-insensitive in Markdown. Both the
+    # full form ![alt][label] and the collapsed ![label][] count.
+    my (%image_label, %link_label);
+    while (/!\[[^\]]*\]\[([^\]]+)\]/g)      { $image_label{lc $1} = 1 }
+    while (/!\[([^\]]*)\]\[\]/g)            { $image_label{lc $1} = 1 }
+    while (/(?<!!)\[[^\]]*\]\[([^\]]+)\]/g) { $link_label{lc $1} = 1 }
+    while (/(?<!!)\[([^\]]*)\]\[\]/g)       { $link_label{lc $1} = 1 }
     # An optional link title after the destination. \x27 is a single quote, spelled that
     # way because this whole program is inside a single-quoted shell string.
     my $title = qr{(?:[ \t]+(?:"[^"]*"|\x27[^\x27]*\x27|\([^()]*\)))?};
@@ -124,12 +135,38 @@ LINK_BASE="$repo_url/blob/$REPO_REF/" \
     s{(\]\([ \t]*)([^)\s]+)($title[ \t]*\))}{
       absolute($2) ? "$1$2$3" : do { print $fh "$2\n"; "$1$ENV{LINK_BASE}$2$3" }
     }ge;
-    # [label]: path
-    s{^(\[[^\]]+\]:[ \t]*)(\S+)[ \t]*$}{
-      absolute($2) ? "$1$2" : do { print $fh "$2\n"; "$1$ENV{LINK_BASE}$2" }
+    # [label]: path -- the base depends on how the label is used, not on the definition,
+    # because a definition consumed by ![alt][label] is an image and needs /raw/ too.
+    s{^(\[([^\]]+)\]:[ \t]*)(\S+)[ \t]*$}{
+      my ($prefix, $label, $target) = ($1, $2, $3);
+      my $key = lc $label;
+      if (absolute($target)) {
+        "$prefix$target";
+      } else {
+        print $fh "$target\n";
+        if ($image_label{$key} && $link_label{$key}) {
+          # One definition cannot be both an HTML page and raw bytes. Left relative so
+          # the leftover scan also refuses it, and reported by label below.
+          print $cfh "$label\n";
+          "$prefix$target";
+        } else {
+          my $base = $image_label{$key} ? $ENV{IMG_BASE} : $ENV{LINK_BASE};
+          "$prefix$base$target";
+        }
+      }
     }gme;
-    END { close($fh) }
+    END { close($fh); close($cfh) }
   ' "$stripped" > "$out"
+
+# A label used by both an image and a link has no single correct base: /raw/ serves the
+# bytes an image needs and /blob/ serves the page a link needs. Rather than guess and
+# break one of them, name the label and stop.
+if [ -s "$conflicts" ]; then
+  echo "Error: $SCRIPT_NAME: these reference labels are used by both an image and a" >&2
+  echo "  link, so no single base is right for them:" >&2
+  sort -u "$conflicts" | sed 's/^/    /' >&2
+  die "give the image and the link separate labels"
+fi
 
 # A rewritten link is only useful if the file is really there; an absolute URL to a
 # missing path is a 404 on the listing instead of a visibly broken relative link.

--- a/scripts/prepare-readme.sh
+++ b/scripts/prepare-readme.sh
@@ -130,14 +130,15 @@ LINK_BASE="$repo_url/blob/$REPO_REF/" \
     # appear in task lists, code spans and fenced examples; three separate false
     # conflicts came out of trying, each one refusing to package a correct README. The
     # file extension is a property of the target alone and needs no document scan.
-    s{^(\[[^\]]+\]:[ \t]*)(\S+)[ \t]*$}{
-      my ($prefix, $target) = ($1, $2);
+    # A definition may carry a title too, exactly as an inline link may.
+    s{^(\[[^\]]+\]:[ \t]*)(\S+)($title[ \t]*)$}{
+      my ($prefix, $target, $suffix) = ($1, $2, $3);
       if (absolute($target)) {
-        "$prefix$target";
+        "$prefix$target$suffix";
       } else {
         print $fh "$target\n";
         my $is_image = $target =~ /\.(?:png|jpe?g|gif|svg|webp|avif|bmp|ico)$/i;
-        "$prefix" . ($is_image ? $ENV{IMG_BASE} : $ENV{LINK_BASE}) . $target;
+        "$prefix" . ($is_image ? $ENV{IMG_BASE} : $ENV{LINK_BASE}) . "$target$suffix";
       }
     }gme;
     END { close($fh) }
@@ -205,7 +206,9 @@ leftover=$(
       $target =~ s/>$//;
       print "$target\n" unless $target =~ m{^(?:\w+:|//|\#)};
     }
-    while (/^\[[^\]]+\]:[ \t]*(\S+)[ \t]*$/gm) {
+    # Only the destination token is inspected, whatever follows it, so this stays broader
+    # than the rewrite for definitions the way it already is for inline links.
+    while (/^\[[^\]]+\]:[ \t]*(\S+)/gm) {
       print "$1\n" unless $1 =~ m{^(?:\w+:|//|\#)};
     }
   ' "$out" | sort -u

--- a/scripts/prepare-readme.sh
+++ b/scripts/prepare-readme.sh
@@ -119,20 +119,31 @@ LINK_BASE="$repo_url/blob/$REPO_REF/" \
     # Which reference labels are used by images, so `[label]: path` can pick the same
     # base an inline image would get. Labels are case-insensitive in Markdown. Both the
     # full form ![alt][label] and the collapsed ![label][] count.
+    # Detection runs over a copy with code removed. A bracket inside a code span or a
+    # fenced block is prose about Markdown, not Markdown, and counting it can only
+    # produce a false conflict -- which refuses to package a README that is entirely
+    # correct. The copy is scanned; the document itself is untouched.
+    my $scan = $_;
+    $scan =~ s/^```.*?^```//gms;
+    $scan =~ s/`[^`\n]*`//g;
     my (%image_label, %link_label);
-    while (/!\[[^\]]*\]\[([^\]]+)\]/g)      { $image_label{lc $1} = 1 }
-    while (/!\[([^\]]*)\]\[\]/g)            { $image_label{lc $1} = 1 }
+    while ($scan =~ /!\[[^\]]*\]\[([^\]]+)\]/g)      { $image_label{lc $1} = 1 }
+    while ($scan =~ /!\[([^\]]*)\]\[\]/g)            { $image_label{lc $1} = 1 }
     # The shortcut form ![label], with no second bracket pair and no parenthesis after.
-    while (/!\[([^\]]+)\](?![\[\(])/g)      { $image_label{lc $1} = 1 }
-    while (/(?<!!)\[[^\]]*\]\[([^\]]+)\]/g) { $link_label{lc $1} = 1 }
-    while (/(?<!!)\[([^\]]*)\]\[\]/g)       { $link_label{lc $1} = 1 }
+    while ($scan =~ /!\[([^\]]+)\](?![\[\(])/g)      { $image_label{lc $1} = 1 }
+    while ($scan =~ /(?<!!)\[[^\]]*\]\[([^\]]+)\]/g) { $link_label{lc $1} = 1 }
+    while ($scan =~ /(?<!!)\[([^\]]*)\]\[\]/g)       { $link_label{lc $1} = 1 }
     # The shortcut link [label], the mirror of the image case above. Every exclusion
     # here was earned: `!` before it is an image, `]` before it is the second half of a
     # full reference which the rules above already classified (counting it here made
     # ![alt][label] register as a link and collide with itself), `[` or `(` after it is
     # some other form, and `:` after it is the definition line, which must not count as
-    # a use of its own label.
-    while (/(?<![!\]])\[([^\]]+)\](?![\[\(:])/g) { $link_label{lc $1} = 1 }
+    # a use of its own label. The second lookbehind drops task list markers: `- [x]` is
+    # a checkbox, and treating it as a reference to a label named x would refuse any
+    # README that has both a task list and an image reference sharing that label.
+    while ($scan =~ /(?<![!\]])(?<![-*+] )\[([^\]]+)\](?![\[\(:])/g) {
+      $link_label{lc $1} = 1;
+    }
     # An optional link title after the destination. \x27 is a single quote, spelled that
     # way because this whole program is inside a single-quoted shell string.
     my $title = qr{(?:[ \t]+(?:"[^"]*"|\x27[^\x27]*\x27|\([^()]*\)))?};

--- a/scripts/prepare-readme.sh
+++ b/scripts/prepare-readme.sh
@@ -113,12 +113,15 @@ LINK_BASE="$repo_url/blob/$REPO_REF/" \
       my ($target) = @_;
       return $target =~ m{^(?:\w+:|//|\#)};
     }
-    # ![alt](path)
-    s{(!\[[^\]]*\]\()([^)\s]+)(\))}{
+    # An optional link title after the destination. \x27 is a single quote, spelled that
+    # way because this whole program is inside a single-quoted shell string.
+    my $title = qr{(?:[ \t]+(?:"[^"]*"|\x27[^\x27]*\x27|\([^()]*\)))?};
+    # ![alt](path) and ![alt](path "title")
+    s{(!\[[^\]]*\]\([ \t]*)([^)\s]+)($title[ \t]*\))}{
       absolute($2) ? "$1$2$3" : do { print $fh "$2\n"; "$1$ENV{IMG_BASE}$2$3" }
     }ge;
-    # [text](path)
-    s{(\]\()([^)\s]+)(\))}{
+    # [text](path) and [text](path "title")
+    s{(\]\([ \t]*)([^)\s]+)($title[ \t]*\))}{
       absolute($2) ? "$1$2$3" : do { print $fh "$2\n"; "$1$ENV{LINK_BASE}$2$3" }
     }ge;
     # [label]: path
@@ -175,10 +178,20 @@ if [ -n "$dangling" ]; then
 fi
 
 # Belt and braces: whatever the rules above did or skipped, nothing relative may ship.
+# This scan is deliberately broader than the rewrite: it takes everything up to the
+# closing paren and inspects the first token, so a form the rewrite cannot handle -- a
+# title shape it does not know, an angle-bracketed destination -- fails the build loudly
+# instead of slipping through as a relative link. Wider here, narrower there, on purpose.
 leftover=$(
   perl -0777 -ne '
-    while (/\]\(([^)\s]+)\)/g) {
-      print "$1\n" unless $1 =~ m{^(?:\w+:|//|\#)};
+    while (/\]\(([^)]*)\)/g) {
+      my $inside = $1;
+      $inside =~ s/^[ \t]+//;
+      my ($target) = $inside =~ /^(\S+)/;
+      next unless defined $target;
+      $target =~ s/^<//;
+      $target =~ s/>$//;
+      print "$target\n" unless $target =~ m{^(?:\w+:|//|\#)};
     }
     while (/^\[[^\]]+\]:[ \t]*(\S+)[ \t]*$/gm) {
       print "$1\n" unless $1 =~ m{^(?:\w+:|//|\#)};

--- a/scripts/test-prepare-readme.sh
+++ b/scripts/test-prepare-readme.sh
@@ -217,6 +217,55 @@ Body.
 See [example](<https://example.com>).
 EOF
 
+# A tab is blank space in Markdown and the refusal has to see it. Worth a case of its own
+# because the first spelling of that check used [ \t], which POSIX reads as space,
+# backslash and the letter t -- it missed the tab and matched a stray t. The local grep on
+# a developer machine may be ugrep, which honours the escape and hides the difference.
+# Written with printf so the tab is unambiguous here rather than a character an editor eats.
+printf '# Title\n\nSee [setup](\t<CONTRIBUTING.md>).\n' > "$WORKSPACE/tab-before-bracket.in"
+got=0
+"$SCRIPT" "$WORKSPACE/tab-before-bracket.in" "$WORKSPACE/tab-before-bracket.out" \
+  > "$WORKSPACE/tab-before-bracket.log" 2>&1 || got=$?
+[ "$got" = 1 ] || fail "tab-before-bracket: expected exit 1, got $got"
+grep -qF "angle-bracketed" "$WORKSPACE/tab-before-bracket.log" ||
+  fail "tab-before-bracket: expected the angle-bracket message"
+
+# --- Reference definitions may be indented ------------------------------------------
+# Markdown allows up to three leading spaces before a definition, four being a code block.
+# The rewrite requires column zero and is deliberately left that way: growing what is
+# refused is safe, growing what is rewritten is what produced the regressions in this
+# branch. What changed is that the leftover scan no longer stops at column zero, so an
+# indented relative definition fails the build instead of shipping unrewritten and
+# unreported -- silently relative, which is the one outcome this script exists to prevent.
+run indented-definition-relative 1 << 'EOF'
+# Title
+
+  [guide]: CONTRIBUTING.md
+
+See the [guide].
+EOF
+grep -qF "relative links survived" "$WORKSPACE/indented-definition-relative.log" ||
+  fail "indented-definition-relative: expected the leftover-scan message"
+
+# The same indent with an absolute target is the form a listing can actually use, so it
+# passes untouched. Refusing it would block a release over nothing.
+run indented-definition-absolute 0 << 'EOF'
+# Title
+
+  [vs]: https://example.com
+
+See the [vs].
+EOF
+has indented-definition-absolute "  [vs]: https://example.com"
+
+run indented-definition-bracketed 1 << 'EOF'
+# Title
+
+  [id]: <https://example.com>
+EOF
+grep -qF "angle-bracketed" "$WORKSPACE/indented-definition-bracketed.log" ||
+  fail "indented-definition-bracketed: expected the angle-bracket message"
+
 # A query or fragment after the extension does not stop it being an image, and does not
 # belong in the path that gets checked for existence either.
 run image-with-query 0 << 'EOF'

--- a/scripts/test-prepare-readme.sh
+++ b/scripts/test-prepare-readme.sh
@@ -137,6 +137,37 @@ run definition-routes-by-extension 0 << 'EOF'
 EOF
 has definition-routes-by-extension "[doc]: $BLOB/CONTRIBUTING.md"
 
+# A definition may carry a title just as an inline link may. Handling it inline without
+# handling it here left the destination unrewritten and unreported -- shipped relative.
+run titled-definition 0 << 'EOF'
+# Title
+
+See [the guide][id].
+
+[id]: CONTRIBUTING.md "setup"
+EOF
+has titled-definition "[id]: $BLOB/CONTRIBUTING.md \"setup\""
+
+run titled-definition-image 0 << 'EOF'
+# Title
+
+![pic][ic]
+
+[ic]: icon.png "the icon"
+EOF
+has titled-definition-image "[ic]: $RAW/icon.png \"the icon\""
+
+# ...and it is still checked for existence, which the old shape skipped entirely.
+run titled-definition-missing 1 << 'EOF'
+# Title
+
+See [the plan][id].
+
+[id]: docs/NOPE.md "t"
+EOF
+grep -qF "not in the repository" "$WORKSPACE/titled-definition-missing.log" ||
+  fail "titled-definition-missing: expected the missing-file message"
+
 # Brackets that are not references at all. Each of these once counted as a shortcut link
 # and produced a conflict against the image, refusing to package a correct README --
 # a false positive on the release path, which is the costlier direction to be wrong in.

--- a/scripts/test-prepare-readme.sh
+++ b/scripts/test-prepare-readme.sh
@@ -124,6 +124,21 @@ EOF
 grep -qF "used by both an image and a" "$WORKSPACE/reference-label-conflict.log" ||
   fail "reference-label-conflict: expected the both-uses message"
 
+# The same collision in shortcut form. Detecting shortcut images without shortcut links
+# made this pair look image-only, so it took /raw/ and the link resolved to raw bytes.
+# Note the reference-image-shortcut case above is what proves the definition line does
+# not count as a use of its own label -- without that exclusion this check would fire on
+# every defined label and nothing would package at all.
+run shortcut-label-conflict 1 << 'EOF'
+# Title
+
+![x] and see [x] too.
+
+[x]: icon.png
+EOF
+grep -qF "used by both an image and a" "$WORKSPACE/shortcut-label-conflict.log" ||
+  fail "shortcut-label-conflict: expected the both-uses message"
+
 # Link titles are legal Markdown and used to slip past the rewrite entirely: the
 # destination pattern stopped at the first space, so a titled relative link was neither
 # rewritten nor reported, which is the one outcome this script exists to prevent.

--- a/scripts/test-prepare-readme.sh
+++ b/scripts/test-prepare-readme.sh
@@ -50,6 +50,14 @@ has() {
   grep -qF "$2" "$WORKSPACE/$1.out" || fail "$1: expected to find $2"
 }
 
+# The missing-target cases need a path that genuinely is not in the repository. Checking
+# that here means adding the file later produces this message rather than an unexplained
+# failure in two fixtures that look like they are about something else.
+MISSING="docs/NOPE.md"
+if [ -e "$REPO_ROOT/$MISSING" ]; then
+  fail "the missing-target fixtures assume $MISSING does not exist, but it does now; point them at another path"
+fi
+
 # --- The original job, pinned to a golden file --------------------------------------
 "$SCRIPT" "$INPUT" "$WORKSPACE/golden.out"
 if ! diff -u "$EXPECTED" "$WORKSPACE/golden.out"; then
@@ -156,6 +164,37 @@ run titled-definition-image 0 << 'EOF'
 [ic]: icon.png "the icon"
 EOF
 has titled-definition-image "[ic]: $RAW/icon.png \"the icon\""
+
+# An absolute destination in angle brackets is absolute; without stripping them it read
+# as relative and the listing was refused over a URL that was already fine.
+run angle-bracket-absolute 0 << 'EOF'
+# Title
+
+See [example][id].
+
+[id]: <https://example.com>
+EOF
+has angle-bracket-absolute "[id]: <https://example.com>"
+
+# A query or fragment after the extension does not stop it being an image, and does not
+# belong in the path that gets checked for existence either.
+run image-with-query 0 << 'EOF'
+# Title
+
+![pic][ic]
+
+[ic]: icon.png?raw=1
+EOF
+has image-with-query "[ic]: $RAW/icon.png?raw=1"
+
+run image-with-fragment 0 << 'EOF'
+# Title
+
+![pic][ic]
+
+[ic]: icon.png#v1
+EOF
+has image-with-fragment "[ic]: $RAW/icon.png#v1"
 
 # ...and it is still checked for existence, which the old shape skipped entirely.
 run titled-definition-missing 1 << 'EOF'

--- a/scripts/test-prepare-readme.sh
+++ b/scripts/test-prepare-readme.sh
@@ -81,6 +81,38 @@ Start with the [guide].
 EOF
 has reference-definition "[guide]: $BLOB/CONTRIBUTING.md"
 
+# Link titles are legal Markdown and used to slip past the rewrite entirely: the
+# destination pattern stopped at the first space, so a titled relative link was neither
+# rewritten nor reported, which is the one outcome this script exists to prevent.
+run titled-link 0 << 'EOF'
+# Title
+
+See [setup](CONTRIBUTING.md "the guide") first.
+EOF
+has titled-link "]($BLOB/CONTRIBUTING.md \"the guide\")"
+
+run titled-image 0 << 'EOF'
+# Title
+
+![icon](icon.png "the icon")
+EOF
+has titled-image "]($RAW/icon.png \"the icon\")"
+
+run single-quoted-title 0 << 'EOF'
+# Title
+
+See [setup](CONTRIBUTING.md 'the guide') first.
+EOF
+has single-quoted-title "]($BLOB/CONTRIBUTING.md 'the guide')"
+
+# A destination shape the rewrite does not handle must fail rather than ship. The
+# leftover scan is deliberately broader than the rewrite so this direction is guaranteed.
+run unsupported-destination 1 << 'EOF'
+# Title
+
+See [setup](<CONTRIBUTING.md>).
+EOF
+
 # A file link carrying an anchor keeps the anchor and is still checked for existence.
 run link-with-anchor 0 << 'EOF'
 # Title

--- a/scripts/test-prepare-readme.sh
+++ b/scripts/test-prepare-readme.sh
@@ -81,6 +81,39 @@ Start with the [guide].
 EOF
 has reference-definition "[guide]: $BLOB/CONTRIBUTING.md"
 
+# A definition consumed by a reference-style image needs /raw/ like an inline image, not
+# the /blob/ every definition used to get -- a blob URL serves HTML and renders broken.
+run reference-image 0 << 'EOF'
+# Title
+
+![the icon][ic]
+
+[ic]: icon.png
+EOF
+has reference-image "[ic]: $RAW/icon.png"
+
+# The collapsed form takes its label from the alt text.
+run reference-image-collapsed 0 << 'EOF'
+# Title
+
+![ic][]
+
+[ic]: icon.png
+EOF
+has reference-image-collapsed "[ic]: $RAW/icon.png"
+
+# One label cannot serve both: /raw/ gives an image its bytes, /blob/ gives a link its
+# page. Naming the label beats silently breaking whichever one loses.
+run reference-label-conflict 1 << 'EOF'
+# Title
+
+![pic][x] and [text][x]
+
+[x]: icon.png
+EOF
+grep -qF "used by both an image and a" "$WORKSPACE/reference-label-conflict.log" ||
+  fail "reference-label-conflict: expected the both-uses message"
+
 # Link titles are legal Markdown and used to slip past the rewrite entirely: the
 # destination pattern stopped at the first space, so a titled relative link was neither
 # rewritten nor reported, which is the one outcome this script exists to prevent.

--- a/scripts/test-prepare-readme.sh
+++ b/scripts/test-prepare-readme.sh
@@ -102,6 +102,16 @@ run reference-image-collapsed 0 << 'EOF'
 EOF
 has reference-image-collapsed "[ic]: $RAW/icon.png"
 
+# ...and the shortcut form, which is just the label with nothing after it.
+run reference-image-shortcut 0 << 'EOF'
+# Title
+
+![ic]
+
+[ic]: icon.png
+EOF
+has reference-image-shortcut "[ic]: $RAW/icon.png"
+
 # One label cannot serve both: /raw/ gives an image its bytes, /blob/ gives a link its
 # page. Naming the label beats silently breaking whichever one loses.
 run reference-label-conflict 1 << 'EOF'

--- a/scripts/test-prepare-readme.sh
+++ b/scripts/test-prepare-readme.sh
@@ -266,6 +266,26 @@ EOF
 grep -qF "angle-bracketed" "$WORKSPACE/indented-definition-bracketed.log" ||
   fail "indented-definition-bracketed: expected the angle-bracket message"
 
+# The indent allowance is spaces, not blank space. A leading tab is a four-column tab
+# stop, so a line starting with one is an indented code block and not a definition -- the
+# first spelling of this allowance counted the tab as one unit and refused a listing over
+# a code example. That is a false positive on the release path, which blocks a release
+# over a file that is correct, and is the costlier of the two directions to be wrong in.
+# printf again, so the tab is unambiguous here.
+printf '# Title\n\nAn example:\n\n\t[foo]: bar.md\n\nDone.\n' \
+  > "$WORKSPACE/tab-indented-code-definition.in"
+printf '# Title\n\nAn example:\n\n\t[foo]: <bar.md>\n\nDone.\n' \
+  > "$WORKSPACE/tab-indented-code-bracketed.in"
+for case in tab-indented-code-definition tab-indented-code-bracketed; do
+  got=0
+  "$SCRIPT" "$WORKSPACE/$case.in" "$WORKSPACE/$case.out" > "$WORKSPACE/$case.log" 2>&1 ||
+    got=$?
+  [ "$got" = 0 ] || {
+    fail "$case: expected exit 0, got $got"
+    sed 's/^/    /' "$WORKSPACE/$case.log" >&2
+  }
+done
+
 # A query or fragment after the extension does not stop it being an image, and does not
 # belong in the path that gets checked for existence either.
 run image-with-query 0 << 'EOF'

--- a/scripts/test-prepare-readme.sh
+++ b/scripts/test-prepare-readme.sh
@@ -139,6 +139,44 @@ EOF
 grep -qF "used by both an image and a" "$WORKSPACE/shortcut-label-conflict.log" ||
   fail "shortcut-label-conflict: expected the both-uses message"
 
+# Brackets that are not references at all. Each of these once counted as a shortcut link
+# and produced a conflict against the image, refusing to package a correct README --
+# a false positive on the release path, which is the costlier direction to be wrong in.
+run task-list-not-a-link 0 << 'EOF'
+# Title
+
+- [x] shipped
+
+![pic][x]
+
+[x]: icon.png
+EOF
+has task-list-not-a-link "[x]: $RAW/icon.png"
+
+run code-span-not-a-link 0 << 'EOF'
+# Title
+
+Write `[x]` to make a checkbox.
+
+![pic][x]
+
+[x]: icon.png
+EOF
+has code-span-not-a-link "[x]: $RAW/icon.png"
+
+run fenced-block-not-a-link 0 << 'EOF'
+# Title
+
+```md
+[x] and ![x]
+```
+
+![pic][x]
+
+[x]: icon.png
+EOF
+has fenced-block-not-a-link "[x]: $RAW/icon.png"
+
 # Link titles are legal Markdown and used to slip past the rewrite entirely: the
 # destination pattern stopped at the first space, so a titled relative link was neither
 # rewritten nor reported, which is the one outcome this script exists to prevent.

--- a/scripts/test-prepare-readme.sh
+++ b/scripts/test-prepare-readme.sh
@@ -112,32 +112,30 @@ run reference-image-shortcut 0 << 'EOF'
 EOF
 has reference-image-shortcut "[ic]: $RAW/icon.png"
 
-# One label cannot serve both: /raw/ gives an image its bytes, /blob/ gives a link its
-# page. Naming the label beats silently breaking whichever one loses.
-run reference-label-conflict 1 << 'EOF'
+# A definition routes on what its target is, not on how the label is used, so the same
+# label serving an image and a link is no longer a conflict -- it resolves once, by
+# extension. The trade is stated by the next two cases rather than left implicit.
+run label-used-both-ways 0 << 'EOF'
 # Title
 
 ![pic][x] and [text][x]
 
 [x]: icon.png
 EOF
-grep -qF "used by both an image and a" "$WORKSPACE/reference-label-conflict.log" ||
-  fail "reference-label-conflict: expected the both-uses message"
+has label-used-both-ways "[x]: $RAW/icon.png"
 
-# The same collision in shortcut form. Detecting shortcut images without shortcut links
-# made this pair look image-only, so it took /raw/ and the link resolved to raw bytes.
-# Note the reference-image-shortcut case above is what proves the definition line does
-# not count as a use of its own label -- without that exclusion this check would fire on
-# every defined label and nothing would package at all.
-run shortcut-label-conflict 1 << 'EOF'
+# The limitation, written down: an image whose definition points at a non-image
+# extension gets /blob/ and would render broken. Nothing in this repository does that,
+# and the alternative -- deciding from usage -- is what produced three separate false
+# conflicts that refused to package correct READMEs.
+run definition-routes-by-extension 0 << 'EOF'
 # Title
 
-![x] and see [x] too.
+![pic][doc]
 
-[x]: icon.png
+[doc]: CONTRIBUTING.md
 EOF
-grep -qF "used by both an image and a" "$WORKSPACE/shortcut-label-conflict.log" ||
-  fail "shortcut-label-conflict: expected the both-uses message"
+has definition-routes-by-extension "[doc]: $BLOB/CONTRIBUTING.md"
 
 # Brackets that are not references at all. Each of these once counted as a shortcut link
 # and produced a conflict against the image, refusing to package a correct README --

--- a/scripts/test-prepare-readme.sh
+++ b/scripts/test-prepare-readme.sh
@@ -1,24 +1,163 @@
 #!/usr/bin/env bash
 
+# Tests for scripts/prepare-readme.sh.
+#
+# The golden case pins the original job -- stripping the zenodo badge and the
+# Documentation section. Everything after it covers link handling, where the failures
+# are invisible rather than loud: a relative link that reaches a marketplace page
+# resolves against the marketplace, and an absolute link to a path that moved is a 404.
+# Neither looks broken from inside the repository, which is why they are asserted here.
+#
+# Link targets are checked against the real repository, so these fixtures reference
+# files that genuinely exist (CONTRIBUTING.md, icon.png) and one that genuinely does not.
+
 set -euo pipefail
 
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/prepare-readme.sh"
 INPUT="test-workspace/README.md"
 EXPECTED="scripts/fixtures/test-readme-expected.md"
-TMP_OUT=""
+BLOB="https://github.com/michen00/invisible-squiggles/blob/main"
+RAW="https://github.com/michen00/invisible-squiggles/raw/main"
+WORKSPACE=""
+FAILURES=0
 
 cleanup() {
-  rm -f "$TMP_OUT"
+  [ -n "$WORKSPACE" ] && rm -rf "$WORKSPACE"
 }
 trap cleanup EXIT
 
-TMP_OUT=$(mktemp)
+WORKSPACE=$(mktemp -d)
 
-# Run the prepare script
-scripts/prepare-readme.sh "$INPUT" "$TMP_OUT"
+fail() {
+  echo "FAIL: $*" >&2
+  FAILURES=$((FAILURES + 1))
+}
 
-# Compare with expected output
-if ! diff -u "$EXPECTED" "$TMP_OUT"; then
-  echo "FAIL: Output does not match expected" >&2
+# run <name> <want-rc>; README body arrives on stdin, output lands in <name>.out
+run() {
+  local name="$1" want="$2" got=0
+  cat > "$WORKSPACE/$name.in"
+  "$SCRIPT" "$WORKSPACE/$name.in" "$WORKSPACE/$name.out" \
+    > "$WORKSPACE/$name.log" 2>&1 || got=$?
+  if [ "$got" != "$want" ]; then
+    fail "$name: expected exit $want, got $got"
+    sed 's/^/    /' "$WORKSPACE/$name.log" >&2
+  fi
+}
+
+has() {
+  grep -qF "$2" "$WORKSPACE/$1.out" || fail "$1: expected to find $2"
+}
+
+# --- The original job, pinned to a golden file --------------------------------------
+"$SCRIPT" "$INPUT" "$WORKSPACE/golden.out"
+if ! diff -u "$EXPECTED" "$WORKSPACE/golden.out"; then
+  fail "golden output no longer matches $EXPECTED"
+fi
+
+# --- Relative links become absolute, with the right base for each kind --------------
+run relative-link 0 << 'EOF'
+# Title
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for setup.
+EOF
+has relative-link "]($BLOB/CONTRIBUTING.md)"
+
+# An image needs /raw/; a blob URL serves an HTML page and renders as a broken image.
+run relative-image 0 << 'EOF'
+# Title
+
+![icon](icon.png)
+EOF
+has relative-image "]($RAW/icon.png)"
+
+run reference-definition 0 << 'EOF'
+# Title
+
+[guide]: CONTRIBUTING.md
+
+Start with the [guide].
+EOF
+has reference-definition "[guide]: $BLOB/CONTRIBUTING.md"
+
+# A file link carrying an anchor keeps the anchor and is still checked for existence.
+run link-with-anchor 0 << 'EOF'
+# Title
+
+See [releases](CONTRIBUTING.md#creating-a-release).
+EOF
+has link-with-anchor "]($BLOB/CONTRIBUTING.md#creating-a-release)"
+
+# --- Absolute targets are left exactly as they are ----------------------------------
+run absolute-untouched 0 << 'EOF'
+# Title
+
+[example](https://example.com/page) and ![badge](https://img.shields.io/badge/a-b-c.svg)
+EOF
+has absolute-untouched "](https://example.com/page)"
+has absolute-untouched "](https://img.shields.io/badge/a-b-c.svg)"
+
+# --- Anchors: allowed when the heading survives the strip ---------------------------
+# The slug matters more than it looks. GitHub lowercases, drops characters that are not
+# alphanumeric, space, hyphen or underscore, then turns spaces into hyphens -- so this
+# repository's emoji headings slug to a leading hyphen, and "#-features" is correct.
+run anchor-resolves 0 << 'EOF'
+# Title
+
+Jump to [Features](#-features).
+
+## 🔹 Features
+
+Body.
+EOF
+
+# ...and rejected when the heading was in the part that got cut, which is damage this
+# transform causes rather than finds.
+run anchor-orphaned 1 << 'EOF'
+# Title
+
+Jump to [the index](#-documentation).
+
+## 🔹 Documentation
+
+- something
+EOF
+grep -qF "anchors point at headings" "$WORKSPACE/anchor-orphaned.log" ||
+  fail "anchor-orphaned: expected the dangling-anchor message"
+
+# --- A link to a path that is not in the repository stops the build ----------------
+run missing-target 1 << 'EOF'
+# Title
+
+See [the plan](docs/NOPE.md).
+EOF
+grep -qF "not in the repository" "$WORKSPACE/missing-target.log" ||
+  fail "missing-target: expected the missing-file message"
+
+# --- Without a usable repository URL, refuse rather than ship relative links -------
+# This is the condition that makes the rewrite necessary in the first place: vsce infers
+# its base from the same field, so a shape it cannot read is exactly when links break.
+printf '# Title\n\nSee [CONTRIBUTING.md](CONTRIBUTING.md).\n' > "$WORKSPACE/nourl.in"
+got=0
+REPO_URL="git@github.com:michen00/invisible-squiggles.git" \
+  "$SCRIPT" "$WORKSPACE/nourl.in" "$WORKSPACE/nourl.out" \
+  > "$WORKSPACE/nourl.log" 2>&1 || got=$?
+[ "$got" = 1 ] || fail "nourl: expected exit 1 for a non-https repository URL, got $got"
+
+# --- REPO_REF chooses the ref the absolute links point at -------------------------
+printf '# Title\n\nSee [CONTRIBUTING.md](CONTRIBUTING.md).\n' > "$WORKSPACE/ref.in"
+REPO_REF=v9.9.9 "$SCRIPT" "$WORKSPACE/ref.in" "$WORKSPACE/ref.out" > /dev/null 2>&1
+grep -qF "/blob/v9.9.9/CONTRIBUTING.md" "$WORKSPACE/ref.out" ||
+  fail "ref: REPO_REF did not reach the rewritten link"
+
+# --- Usage ------------------------------------------------------------------------
+if "$SCRIPT" > /dev/null 2>&1; then
+  fail "expected a usage error with no arguments"
+fi
+
+if [ "$FAILURES" -ne 0 ]; then
+  echo "prepare-readme.sh: $FAILURES test(s) failed" >&2
   exit 1
 fi
 

--- a/scripts/test-prepare-readme.sh
+++ b/scripts/test-prepare-readme.sh
@@ -165,16 +165,57 @@ run titled-definition-image 0 << 'EOF'
 EOF
 has titled-definition-image "[ic]: $RAW/icon.png \"the icon\""
 
-# An absolute destination in angle brackets is absolute; without stripping them it read
-# as relative and the listing was refused over a URL that was already fine.
-run angle-bracket-absolute 0 << 'EOF'
+# --- Angle-bracketed destinations are refused, whatever is inside them ---------------
+# The bracket form is legal Markdown that nothing here reads. It was briefly accepted by
+# stripping the bracket wherever a destination is inspected, which is a rule that has to
+# be repeated in every such place; the place that was missed treated `<#x>` as an anchor
+# and let a link into the removed section ship. One refusal covers the family instead, so
+# the three cases below differ only in what the brackets contain.
+run angle-bracket-url 1 << 'EOF'
 # Title
 
 See [example][id].
 
 [id]: <https://example.com>
 EOF
-has angle-bracket-absolute "[id]: <https://example.com>"
+grep -qF "angle-bracketed" "$WORKSPACE/angle-bracket-url.log" ||
+  fail "angle-bracket-url: expected the angle-bracket message"
+
+run angle-bracket-path 1 << 'EOF'
+# Title
+
+See [setup](<CONTRIBUTING.md>).
+EOF
+grep -qF "angle-bracketed" "$WORKSPACE/angle-bracket-path.log" ||
+  fail "angle-bracket-path: expected the angle-bracket message"
+
+# The one that shipped: an anchor into the stripped section, bracketed. It reached the
+# listing because `absolute()` saw an anchor after dropping the bracket while the
+# dangling-anchor scan, which looks for `](#`, did not see one at all.
+run angle-bracket-anchor 1 << 'EOF'
+# Title
+
+Jump to [the index](<#-documentation>).
+
+## 🔹 Documentation
+
+- something
+EOF
+grep -qF "angle-bracketed" "$WORKSPACE/angle-bracket-anchor.log" ||
+  fail "angle-bracket-anchor: expected the angle-bracket message"
+
+# ...but only in the part that survives. Refusing over a bracket in the section that is
+# cut would fail the release for something no reader of the listing could ever reach --
+# a false positive on the release path, the costlier direction to be wrong in.
+run angle-bracket-below-cut 0 << 'EOF'
+# Title
+
+Body.
+
+## 🔹 Documentation
+
+See [example](<https://example.com>).
+EOF
 
 # A query or fragment after the extension does not stop it being an image, and does not
 # belong in the path that gets checked for existence either.
@@ -269,13 +310,19 @@ See [setup](CONTRIBUTING.md 'the guide') first.
 EOF
 has single-quoted-title "]($BLOB/CONTRIBUTING.md 'the guide')"
 
-# A destination shape the rewrite does not handle must fail rather than ship. The
-# leftover scan is deliberately broader than the rewrite so this direction is guaranteed.
+# A destination shape the rewrite does not handle must fail rather than ship, including
+# shapes nobody has thought to name. Two titles is one such: the rewrite's title pattern
+# matches one and then wants the closing paren, so the link is passed over silently. The
+# leftover scan takes everything up to that paren and inspects the first token, which is
+# why it is deliberately broader than the rewrite -- the gap fails loudly instead of
+# shipping relative.
 run unsupported-destination 1 << 'EOF'
 # Title
 
-See [setup](<CONTRIBUTING.md>).
+See [setup](CONTRIBUTING.md "one" "two").
 EOF
+grep -qF "relative links survived" "$WORKSPACE/unsupported-destination.log" ||
+  fail "unsupported-destination: expected the leftover-scan message"
 
 # A file link carrying an anchor keeps the anchor and is still checked for existence.
 run link-with-anchor 0 << 'EOF'


### PR DESCRIPTION
## The status bar button was described wrong

The Quickstart told readers to click a **👁️ Toggle Squiggles** button. There is no such button. `setStatus` in `src/extension.ts` writes `Squiggles: $(eye)`, switching to `$(eye-closed)` when squiggles are hidden — so the status bar reads **Squiggles:** followed by an eye. "Toggle Squiggles" is the command palette title, which the other two Quickstart options already use correctly.

Someone scanning their status bar for that label would not have found it, and the old wording also lost the fact that the icon reflects the current state.

## The listing pointed at files with relative links

`README.md` carries two relative links, on the PRs-welcome and license badges. After packaging they resolve, but only because `vsce` rewrites relative links against a base it infers from `package.json`'s `repository` field — confirmed by unzipping the built `.vsix`, where both arrive as `blob/HEAD` URLs.

That is fine until the field changes shape, and then it fails in the worst way available: a relative link on a marketplace page resolves against the marketplace, so a reader gets a 404 while the repository looks perfectly correct from the inside. Nothing in the repository would have caught it.

`scripts/prepare-readme.sh` now does the rewriting itself, which makes the result explicit, identical on Open VSX, and testable. Images go through `/raw/` and links through `/blob/`, the same split `vsce` draws between `baseImagesUrl` and `baseContentUrl` — a blob URL serves an HTML page, so an image pointed at one renders as broken rather than as a picture.

Three refusals come with it, because rewriting alone can still emit something unreachable:

| Refused | Why it matters |
| --- | --- |
| No usable repository URL | This is the exact condition that makes the rewrite necessary, so it stops the build rather than quietly shipping relative links. |
| A link to a path not in the repository | As an absolute URL that is a 404 on the listing, where a relative link would at least have looked broken locally. |
| An anchor into the stripped Documentation section | Cutting that section is what orphans such an anchor, so this is the transform checking damage it causes rather than damage it finds. |

The anchor check decodes UTF-8 explicitly. Comparing bytes lets a stray byte of a multi-byte character count as alphanumeric, which made every anchor under one of this README's emoji headings look dangling — the check failed its own fixture until that was fixed.

## How this was checked

`make check` passes, including the extended `scripts/test-prepare-readme.sh`: the original golden case still holds, relative links and images land on the right base, absolute targets are untouched, an anchor to a surviving heading passes while one into the stripped section fails, a missing target fails, a non-https repository URL fails, and `REPO_REF` reaches the rewritten link.

The whole pipeline was also run for real. `make package-vsix`, then unzipping the result, shows the packaged listing carrying `blob/main` URLs for `CONTRIBUTING.md` and `LICENSE`, no relative links at all, and the corrected Option 1 text.

Anchor slugs follow the rule GitHub uses — lowercase, drop anything that is not alphanumeric, space, hyphen or underscore, then spaces to hyphens — which is why `## 🔹 Features` is reachable as `#-features`. There is a case pinning that, and one proving an accented heading keeps its letter.

## Not included

The demo GIF still predates the status bar icon. It is unchanged here and remains the one thing on the listing that misrepresents the extension.
