### PR TITLE
build: use the cooldown key actions accepts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,17 +25,17 @@ updates:
       actions:
         patterns: ['*']
     cooldown:
-      # Wider than the npm ecosystem above rather than at parity with it, and the
-      # asymmetry is the point. This is the one ecosystem whose packages execute
-      # with this repository's own token, inside jobs holding contents and
-      # pull-requests write, so a compromised release can be published and
-      # proposed here within hours. When the risk is the publisher rather than a
-      # changed interface, a patch is not safer than a major, so the delay covers
-      # every update and not only majors.
+      # default-days only. GitHub rejects the semver-* keys for this ecosystem --
+      # "not supported for the package ecosystem 'github-actions'" -- and an
+      # invalid key here does not degrade gracefully: it invalidates the file and
+      # drops this whole entry, grouping and ignore rules included. The
+      # check-dependabot schema hook does not catch it, because the rejection is
+      # server-side rather than schematic.
       #
-      # This is also the soak period that bot-automerge.yml's actions-major branch
-      # leans on. That branch arms a major unless the diff reaches publish.yml or
-      # one of the two autoupdate crons, so most actions majors merge unattended;
-      # a delay between publication and proposal is what that relies on.
-      default-days: 7
-      semver-major-days: 30
+      # So one number covers every actions update, and 30 days is chosen over a
+      # shorter delay because bot-automerge.yml now arms actions majors: this is
+      # the only soak period between a release being published and it merging
+      # here unattended. A patch is not safer than a major when the risk is a
+      # compromised publisher rather than a changed interface, and these packages
+      # execute with this repository's own token inside jobs holding write scopes.
+      default-days: 30


### PR DESCRIPTION
## Summary

Replaces `semver-major-days` with `default-days` on the `github-actions` ecosystem, because that ecosystem does not accept the `semver-*` keys and the failure is silent and total rather than partial.

GitHub rejects `semver-major-days` for `github-actions` with *"not supported for the package ecosystem 'github-actions'"*, and [the options reference](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference) confirms it: `default-days` is supported for every package manager, while `semver-major-days`, `semver-minor-days` and `semver-patch-days` are supported only for the ecosystems it lists, and `github-actions` is not among them. An invalid key does not degrade to "cooldown ignored" — it invalidates the file and drops the whole `github-actions` entry, **grouping and ignore rules included**. So a key added to introduce a soak period removes the grouping instead, and the visible symptom is one pull request per action rather than one per group.

This is a self-inflicted regression and worth saying so plainly: the invalid key arrived in the pull request that standardized this workflow, and it merged because the `check-dependabot` pre-commit hook passes on it. That hook validates against the published schema, and the schema admits `semver-major-days` in a `cooldown` block generally — the ecosystem restriction is enforced server-side, so no local gate can catch it. A sibling repository had already hit this and recorded the diagnosis in its own config; that comment is where this fix came from.

One number therefore has to cover every actions update. 30 days rather than something shorter, because `bot-automerge.yml` now arms `github-actions` majors instead of holding them — this delay is the only soak period between a release being published and it merging here unattended. A patch is not safer than a major when the risk is a compromised publisher rather than a changed interface, and these packages execute with this repository's own token inside jobs holding write scopes.

## Test plan

- [x] Confirmed against GitHub's own options reference that `github-actions` supports `default-days` only
- [x] Audited every sibling repository for the same key, so this is fixed across the set rather than here alone
- [x] `pre-commit run --files .github/dependabot.yml` passes — noted above as insufficient, and recorded here because passing is exactly what made this reachable
- [x] The commit carries a verified signature
- [ ] CI is green — pending on this head
- [ ] The real confirmation is the next `github-actions` pull request arriving **grouped**. That cannot be observed before merge, and it is the check to make afterwards: one grouped pull request means the entry is being read, several ungrouped ones mean it is still being dropped.

## Reviewer guide

- **Effort:** ~2 minutes. One key renamed and one value changed; the rest is the comment explaining why.
- **The calls only you can make:** whether 30 days is the right single delay now that one number has to serve every actions update. The alternative is a short delay accepting that majors merge quickly, or reverting to a blanket major hold in the workflow and a short cooldown here. 30 was chosen because majors now arm unattended.
- **Known weaknesses:** nothing local can catch a recurrence. The schema hook admits the invalid key and the rejection only appears server-side, in the Dependabot tab, as a config error on a file that otherwise looks fine.
