### PR TITLE
build: accept a cycle with no changelog entries

### DIFF
--- a/scripts/update-unreleased.sh
+++ b/scripts/update-unreleased.sh
@@ -436,14 +436,31 @@ awk '
 # A bare heading is written instead, so the section exists for a human to fill and for
 # prep-release.sh to promote into the new version.
 #
-# Guarded on git-cliff having produced something. An empty CLIFF_OUTPUT means it never
-# rendered its template, which is a real failure and still stops here -- the distinction
-# being between "ran and had nothing to report" and "did not run".
+# Two guards, because "the extractor found nothing" has three causes and only one of
+# them is benign. An empty CLIFF_OUTPUT means git-cliff never rendered its template at
+# all. Entries rendered under a heading the extractor does not match means the
+# extraction failed, not that there was nothing to extract -- and writing a bare heading
+# there would drop real changelog content on the floor, silently, which is worse than
+# the error this replaces. Only the third case, genuinely nothing unreleased, is normal.
+#
+# The second guard reads content rather than headings on purpose: it looks at everything
+# git-cliff renders above the first released section, which is the unreleased region
+# whatever heading that region happens to carry. A retitled heading is exactly the case
+# where a heading-based check would agree with the extractor and be wrong with it.
 if [ ! -s "$TEMP_FILE" ]; then
   if [ ! -s "$CLIFF_OUTPUT" ]; then
     echo "Error: git cliff produced no output at all" >&2
     exit 1
   fi
+
+  if awk '/^## \[[0-9]/ { exit } /^### |^- / { found = 1 } END { exit !found }' \
+    "$CLIFF_OUTPUT"; then
+    echo "Error: git cliff rendered unreleased entries that could not be extracted." >&2
+    echo "  The extractor matches a literal '## [Unreleased]' heading; if cliff.toml" >&2
+    echo "  now renders that section differently, update the extractor to match." >&2
+    exit 1
+  fi
+
   echo "No unreleased entries: every commit since the last tag is a type cliff.toml skips."
   printf '## [Unreleased]\n' > "$TEMP_FILE"
 fi

--- a/scripts/update-unreleased.sh
+++ b/scripts/update-unreleased.sh
@@ -427,11 +427,25 @@ awk '
   in_unreleased { print }
 ' "$CLIFF_OUTPUT" > "$TEMP_FILE"
 
-# Check if we got valid content
+# No Unreleased section is a normal outcome, not a failure. cliff.toml skips docs,
+# build, ci, test, refactor, style and chore, so a cycle made only of those produces no
+# section at all -- and that is exactly the release prep-release.sh warns will need a
+# hand-written sentence. Erroring here made that release impossible to prepare with the
+# tooling: `make prep-release` stopped on it after having already bumped the version.
+#
+# A bare heading is written instead, so the section exists for a human to fill and for
+# prep-release.sh to promote into the new version.
+#
+# Guarded on git-cliff having produced something. An empty CLIFF_OUTPUT means it never
+# rendered its template, which is a real failure and still stops here -- the distinction
+# being between "ran and had nothing to report" and "did not run".
 if [ ! -s "$TEMP_FILE" ]; then
-  echo "Error: No Unreleased section found in git cliff output" >&2
-  rm -f "$TEMP_FILE" "$CLIFF_OUTPUT"
-  exit 1
+  if [ ! -s "$CLIFF_OUTPUT" ]; then
+    echo "Error: git cliff produced no output at all" >&2
+    exit 1
+  fi
+  echo "No unreleased entries: every commit since the last tag is a type cliff.toml skips."
+  printf '## [Unreleased]\n' > "$TEMP_FILE"
 fi
 
 # Remove trailing whitespace and ensure the extracted section ends with exactly one newline


### PR DESCRIPTION
## What

`scripts/update-unreleased.sh` treated "git-cliff produced no Unreleased section" as a fatal error. It is a normal outcome, and it now writes a bare `## [Unreleased]` heading instead.

## Why

`cliff.toml` skips `docs`, `build`, `ci`, `test`, `refactor`, `style` and `chore`. A release cycle made only of those generates no changelog entries, so git-cliff emits no `## [Unreleased]` heading at all — and the script exited 1 on the missing section.

That cycle is not a corner case here. It is the documented one: `scripts/prep-release.sh` says in its own header that such a release "is often empty, and an empty section needs a human sentence rather than a default one", and CONTRIBUTING.md repeats the instruction in step 2 of the release procedure. Both describe how to write the entry for a release the tooling could not actually prepare.

The failure is not graceful. `prep-release.sh` bumps the version in `package.json` and `package-lock.json` *before* calling this script, so the error leaves a release branch with a bumped version, no changelog section, and nothing committed — recoverable only by hand.

## How

An empty extraction writes `## [Unreleased]`, which is the heading `prep-release.sh` then promotes into the new version's dated section.

The genuine failure is still caught, and the distinction is the substance of the change: an empty *extraction* means git-cliff ran and had nothing to report, while empty *output* means it never rendered its template. Only the second is an error now.

## Verification

Against a tree whose last seven commits are all `ci`, `build` or `docs`:

```console
$ scripts/update-unreleased.sh
No unreleased entries: every commit since the last tag is a type cliff.toml skips.
Unreleased section is already up-to-date.
$ echo $?
0
```

`CHANGELOG.md` is left byte-identical, which is correct — it already carries an empty `## [Unreleased]` heading. `make check` passes.

## Notes for review

- The three release scripts have no test harness, so this follows that convention rather than introducing one for a single branch. It is exercised end to end by the release it unblocks.
- Typed `build` rather than `fix` on purpose. `fix` is a user-facing changelog category, and this changes release tooling with no effect on the published extension; `build` is skipped by `cliff.toml` and keeps it out of the release notes.
