### PR TITLE
chore: release v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com) and this p
 
 ## [Unreleased]
 
+## [0.4.2](https://github.com/michen00/invisible-squiggles/compare/v0.4.1..v0.4.2) - 2026-08-06
+
+No functional changes. The extension behaves exactly as it did in 0.4.1. This release exists to correct the marketplace listings, which can only be updated by publishing a version.
+
+### 📝 Documentation
+
+- Correct the status bar description: the **Squiggles:** entry sits at the bottom right, and the eye beside it is open while squiggles are visible and closed while they are hidden - ([#256](https://github.com/michen00/invisible-squiggles/pull/256))
+- Every link in the marketplace listings now points at GitHub, so none resolves against the marketplace or lands on a file a reader of the listing cannot reach - ([#256](https://github.com/michen00/invisible-squiggles/pull/256))
+
 ## [0.4.1](https://github.com/michen00/invisible-squiggles/compare/v0.4.0..v0.4.1) - 2026-08-04
 
 No functional changes. The extension behaves exactly as it did in 0.4.0.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "invisible-squiggles",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "invisible-squiggles",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "SEE LICENSE IN LICENSE",
       "devDependencies": {
         "@types/mocha": "^10.0.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "invisible-squiggles",
   "displayName": "invisible squiggles",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "publisher": "michen00",
   "description": "toggle the transparency of diagnostic squiggles for distraction-free coding",
   "author": {


### PR DESCRIPTION
## What

Cuts v0.4.2: version bump in `package.json` and `package-lock.json`, plus a hand-written changelog section.

## Why now

This is a listing-only release. `dist/extension.js` is byte-identical to 0.4.1, and of everything that ships inside the VSIX, `README.md` is the only file that differs.

That matters because both marketplace listings are rendered from the published package. A correction to the README sits on GitHub and reaches nobody browsing the extension until some version carries it. Two corrections are waiting:

- The status bar description named the wrong corner and described the eye icon backwards.
- Links in the listing were relative, so they resolved against the marketplace rather than GitHub — a reader clicking one either landed nowhere useful or got a 404.

## Why the changelog section is hand-written

All seven commits since v0.4.1 are `ci`, `build` or `docs`, and `cliff.toml` skips every one of those types, so git-cliff generates no entries at all. The release procedure in CONTRIBUTING.md anticipates exactly this and asks for the empty case to be stated outright rather than shipped as a bare version heading.

## Verification

- `make check` passes at the bumped version.
- `make package-vsix` produces a listing whose twenty destinations are all absolute, with the repository index section stripped.

## After merge

`make tag VERSION=v0.4.2` signs and pushes the tag, which drafts the release with an attested VSIX and publishes to no registry. The draft is then reviewed before `make release VERSION=v0.4.2`, which is the irreversible step — neither registry allows replacing a published version.
