### PR TITLE
build: narrow what the listing transform handles

### DIFF
--- a/scripts/prepare-readme.sh
+++ b/scripts/prepare-readme.sh
@@ -8,16 +8,34 @@
 #      does not trust, and the Documentation section goes along with everything after
 #      it, because that section is a repository index -- nobody reading a marketplace
 #      page can follow it.
-#   2. Every remaining relative link is rewritten to an absolute GitHub URL. vsce does
-#      this too, inferring a base from package.json's `repository` field, but a listing
-#      that leans on that inference breaks quietly when the field changes shape: a
-#      relative link on a marketplace page resolves against the marketplace, not
-#      against GitHub. Doing it here makes the result explicit, testable, and the same
-#      on Open VSX.
-#   3. The output is then checked for anything unreachable -- a relative link that
-#      survived, a link to a file that is not in the repository, or an anchor pointing
+#   2. Relative destinations are rewritten to absolute GitHub URLs. vsce does this too,
+#      inferring a base from package.json's `repository` field, but a listing that leans
+#      on that inference breaks quietly when the field changes shape: a relative link on
+#      a marketplace page resolves against the marketplace, not against GitHub. Doing it
+#      here makes the result explicit, testable, and the same on Open VSX.
+#   3. The output is then checked for anything unreachable -- a destination that is still
+#      relative, a link to a file that is not in the repository, or an anchor pointing
 #      into the section step 1 just removed. That last one is damage this transform
 #      causes rather than finds, which is the reason it checks.
+#
+# THE CONTRACT, which is deliberately small:
+#
+#   Rewritten:  [text](path) and ![alt](path), destination only, no title.
+#   Untouched:  any destination that is already absolute.
+#   Refused:    everything else -- titles, angle brackets, reference definitions with
+#               relative targets, anchors into the removed section.
+#
+# The refusal list is not a list of gaps. An earlier version of this script tried to
+# handle those forms and grew a title pattern, a bracket-stripping rule, an extension
+# router for definitions and an indent allowance; each addition produced the next defect,
+# three of them regressions from the fix before. None of that grammar made the listing
+# safer, because the guarantee -- nothing relative ships -- is enforced by the leftover
+# scan at the bottom, which reads the output and is indifferent to how it was produced.
+#
+# So the rewrite handles what this README uses and the scan refuses the rest. The input
+# is one file, in this repository, written by the people who get the error, and checked
+# by CI: "make it absolute or write it plainly" costs an author seconds. That reasoning
+# is what makes narrowness right here and would not transfer to a general Markdown tool.
 
 set -euo pipefail
 
@@ -29,8 +47,12 @@ usage() {
 Usage: $SCRIPT_NAME <input-file> <output-file>
 
 Strips the zenodo badge and the Documentation section from a README, rewrites relative
-links to absolute GitHub URLs, and refuses to write a listing that points at anything a
-reader of that listing could not reach.
+destinations to absolute GitHub URLs, and refuses to write a listing that points at
+anything a reader of that listing could not reach.
+
+Rewrites [text](path) and ![alt](path) when the destination is a plain relative path.
+Any other shape -- a title, angle brackets, a reference definition pointing somewhere
+relative -- is refused rather than rewritten; write those as absolute URLs.
 
 Arguments:
   <input-file>   Path to the input README.md
@@ -99,29 +121,19 @@ trap cleanup EXIT
 sed -e '/zenodo\.org.*\.svg/d' -e '/## .*Documentation/,$d' "$in" |
   perl -0777 -pe 's/\s+$/\n/' > "$stripped"
 
-# Markdown allows a destination to be wrapped in angle brackets, and nothing below reads
-# that shape. Refusing it by name is the contract in one rule: a form the rewrite does not
-# understand stops the build with an instruction, rather than being taught to the rewrite
-# one shape at a time. Teaching it was tried -- the bracket then had to be stripped in
-# every place that inspects a destination, and the place that was missed let an anchor
-# into the removed section ship. Checked against the stripped text so brackets in the part
-# that never reaches the listing do not refuse a README that is fine.
-# [[:blank:]] rather than [ \t]: POSIX drops the special meaning of a backslash inside a
-# bracket expression, so [ \t] is space, backslash and the letter t. BSD grep reads it that
-# way -- it misses a tab and matches a stray t -- while the ugrep some machines alias to
-# grep honours the escape, so a local run agrees with the intent and CI does not.
-# The indent allowance is spaces only, for the reason given at the leftover scan below:
-# a leading tab makes the line an indented code block rather than a definition.
-bracketed=$(grep -E '\]\([[:blank:]]*<|^ {0,3}\[[^]]+\]:[[:blank:]]*<' "$stripped" || true)
-if [ -n "$bracketed" ]; then
-  echo "Error: $SCRIPT_NAME: angle-bracketed link destinations are not supported:" >&2
-  printf '%s\n' "$bracketed" | sed 's/^/  /' >&2
-  die "write the destination plainly, without < >"
-fi
-
 # Images resolve through /raw/ and links through /blob/ -- the same split vsce draws
 # between baseImagesUrl and baseContentUrl. A blob URL serves an HTML page, so an image
 # pointed at one renders as a broken image rather than a picture.
+#
+# Only two forms, and the destination is a plain token in both: no whitespace, no angle
+# brackets, no quotes. That character class is the contract. A titled destination has a
+# space in it and an angle-bracketed one starts with `<`, so neither matches, and both
+# fall through unrewritten to the scan at the bottom, which names them.
+#
+# Excluding `<` matters more than it looks. Without it the rewrite happily treats
+# `<CONTRIBUTING.md>` as a path, bolts a GitHub base onto it, and the failure surfaces
+# from the existence check as "links '<CONTRIBUTING.md>', which is not in the
+# repository" -- true, useless, and pointing at the wrong repair.
 LINK_BASE="$repo_url/blob/$REPO_REF/" \
   IMG_BASE="$repo_url/raw/$REPO_REF/" \
   TARGETS="$targets" \
@@ -133,36 +145,15 @@ LINK_BASE="$repo_url/blob/$REPO_REF/" \
       my ($target) = @_;
       return $target =~ m{^(?:\w+:|//|\#)};
     }
-    # An optional link title after the destination. \x27 is a single quote, spelled that
-    # way because this whole program is inside a single-quoted shell string.
-    my $title = qr{(?:[ \t]+(?:"[^"]*"|\x27[^\x27]*\x27|\([^()]*\)))?};
-    # ![alt](path) and ![alt](path "title")
-    s{(!\[[^\]]*\]\([ \t]*)([^)\s]+)($title[ \t]*\))}{
+    # Images first: ![alt](path) also contains the ](path) the link rule matches, so the
+    # generic rule would otherwise give an image the /blob/ base and render it broken.
+    my $dest = qr{[^)\s<>"\x27]+};
+    s{(!\[[^\]]*\]\()($dest)(\))}{
       absolute($2) ? "$1$2$3" : do { print $fh "$2\n"; "$1$ENV{IMG_BASE}$2$3" }
     }ge;
-    # [text](path) and [text](path "title")
-    s{(\]\([ \t]*)([^)\s]+)($title[ \t]*\))}{
+    s{(\]\()($dest)(\))}{
       absolute($2) ? "$1$2$3" : do { print $fh "$2\n"; "$1$ENV{LINK_BASE}$2$3" }
     }ge;
-    # [label]: path -- a definition carries no `!` to say whether it feeds an image or a
-    # link, so the base comes from what the target *is* rather than from how the label is
-    # used. Reading usage means classifying every bracket in the document, and brackets
-    # appear in task lists, code spans and fenced examples; three separate false
-    # conflicts came out of trying, each one refusing to package a correct README. The
-    # file extension is a property of the target alone and needs no document scan.
-    # A definition may carry a title too, exactly as an inline link may.
-    s{^(\[[^\]]+\]:[ \t]*)(\S+)($title[ \t]*)$}{
-      my ($prefix, $target, $suffix) = ($1, $2, $3);
-      if (absolute($target)) {
-        "$prefix$target$suffix";
-      } else {
-        print $fh "$target\n";
-        # A query or fragment may follow the extension -- icon.png?raw=1 is still a png.
-        my $is_image =
-          $target =~ /\.(?:png|jpe?g|gif|svg|webp|avif|bmp|ico)(?:[?\#]\S*)?$/i;
-        "$prefix" . ($is_image ? $ENV{IMG_BASE} : $ENV{LINK_BASE}) . "$target$suffix";
-      }
-    }gme;
     END { close($fh) }
   ' "$stripped" > "$out"
 
@@ -213,15 +204,19 @@ if [ -n "$dangling" ]; then
   die "the Documentation section and everything below it is stripped, so an anchor into it cannot resolve"
 fi
 
-# Belt and braces: whatever the rules above did or skipped, nothing relative may ship.
-# This scan is deliberately broader than the rewrite: it takes everything up to the
-# closing paren and inspects the first token, so a form the rewrite cannot handle -- a
-# title shape it does not know, for instance -- fails the build loudly instead of slipping
-# through as a relative link. Wider here, narrower there, on purpose.
+# This is the guarantee. Everything above is convenience; this is the part that makes the
+# listing safe, and it holds whatever the rewrite did or skipped, because it reads the
+# output rather than trusting the transform.
 #
-# It normalises nothing, deliberately. Stripping angle brackets here would make `<#x>`
-# read as an anchor and pass, which is the same assumption the check above already makes;
-# a second barrier that shares the first one's blind spot is not a second barrier.
+# It is deliberately wider than the rewrite. The rewrite matches a bare destination token;
+# this takes everything up to the closing paren and inspects the first token, so every
+# shape the rewrite declines -- a title, angle brackets, something nobody has thought of
+# -- arrives here still relative and stops the build. Wider here, narrower there, on
+# purpose: that gap is where the contract lives.
+#
+# It normalises nothing, also deliberately. Stripping angle brackets would make `<#x>`
+# read as an anchor and pass; a barrier that shares the rewrite's blind spots is not a
+# barrier.
 leftover=$(
   perl -0777 -ne '
     while (/\]\(([^)]*)\)/g) {
@@ -231,24 +226,19 @@ leftover=$(
       next unless defined $target;
       print "$target\n" unless $target =~ m{^(?:\w+:|//|\#)};
     }
-    # Only the destination token is inspected, whatever follows it, so this stays broader
-    # than the rewrite for definitions the way it already is for inline links. It also
-    # allows the indent Markdown allows -- up to three spaces, four being a code block --
-    # which the rewrite above deliberately does not. Growing what is refused is safe;
-    # growing what is rewritten is what produced the regressions in this branch. So an
-    # indented relative definition stops the build rather than being rewritten, and an
-    # indented absolute one passes untouched, which is every case this repository has.
-    #
-    # Spaces only, not [ \t]. A leading tab is a four-column tab stop, so a line starting
-    # with one is an indented code block and not a definition at all; counting it as one
-    # unit of indent made a tab-indented code example refuse the whole listing.
+    # Reference definitions are never rewritten, so this is the only thing that reads
+    # them: an absolute one passes, a relative one stops the build. The indent allowance
+    # is the three spaces Markdown allows, spaces only -- a leading tab is a four-column
+    # tab stop, which makes the line an indented code block rather than a definition.
     while (/^ {0,3}\[[^\]]+\]:[ \t]*(\S+)/gm) {
       print "$1\n" unless $1 =~ m{^(?:\w+:|//|\#)};
     }
   ' "$out" | sort -u
 )
 if [ -n "$leftover" ]; then
-  echo "Error: $SCRIPT_NAME: relative links survived into the listing:" >&2
+  echo "Error: $SCRIPT_NAME: these destinations would not resolve on a listing page:" >&2
   printf '%s\n' "$leftover" | sed 's/^/  /' >&2
-  die "a relative link on a marketplace page resolves against the marketplace"
+  die "the listing rewrites [text](path) and ![alt](path) with a plain destination.
+Anything else -- a title, angle brackets, a reference definition -- has to be written as
+an absolute URL, because a relative one resolves against the marketplace, not GitHub."
 fi

--- a/scripts/prepare-readme.sh
+++ b/scripts/prepare-readme.sh
@@ -51,8 +51,8 @@ destinations to absolute GitHub URLs, and refuses to write a listing that points
 anything a reader of that listing could not reach.
 
 Rewrites [text](path) and ![alt](path) when the destination is a plain relative path.
-Any other shape -- a title, angle brackets, a reference definition pointing somewhere
-relative -- is refused rather than rewritten; write those as absolute URLs.
+Any other shape -- a title, angle brackets, a reference definition -- is refused rather
+than rewritten. Write the link in that plain form, or make the destination absolute.
 
 Arguments:
   <input-file>   Path to the input README.md
@@ -236,9 +236,12 @@ leftover=$(
   ' "$out" | sort -u
 )
 if [ -n "$leftover" ]; then
-  echo "Error: $SCRIPT_NAME: these destinations would not resolve on a listing page:" >&2
+  echo "Error: $SCRIPT_NAME: these destinations reach the listing unrewritten:" >&2
   printf '%s\n' "$leftover" | sed 's/^/  /' >&2
-  die "the listing rewrites [text](path) and ![alt](path) with a plain destination.
-Anything else -- a title, angle brackets, a reference definition -- has to be written as
-an absolute URL, because a relative one resolves against the marketplace, not GitHub."
+  die "only [text](path) and ![alt](path) with a plain destination are rewritten, and a
+relative destination left alone resolves against the marketplace, not GitHub. Either write
+the link in that plain form -- drop the title, drop the angle brackets -- or make the
+destination absolute. A reference definition is never rewritten, so absolute is the only
+option there. Angle brackets are refused even around an already-absolute URL: this scan
+reads the destination literally rather than normalising it."
 fi

--- a/scripts/test-prepare-readme.sh
+++ b/scripts/test-prepare-readme.sh
@@ -60,9 +60,15 @@ has() {
 # Every refusal must name the destination it is refusing. The exit code alone is too weak
 # an assertion: a refusal that fires for the wrong reason still exits 1, and that is how
 # a check keeps passing after it has stopped testing what it was written for.
+#
+# The plain-form repair is asserted too, because the message is the only place an author
+# learns that option exists. An earlier version offered an absolute URL as the only fix,
+# which is the wrong advice for a title and meaningless for a URL already absolute.
 refused() {
-  grep -qF "would not resolve on a listing page" "$WORKSPACE/$1.log" ||
+  grep -qF "reach the listing unrewritten" "$WORKSPACE/$1.log" ||
     fail "$1: expected the unsupported-destination message"
+  grep -qF "plain form" "$WORKSPACE/$1.log" ||
+    fail "$1: expected the message to offer the plain-form repair"
   grep -qF "$2" "$WORKSPACE/$1.log" ||
     fail "$1: expected the message to name $2"
 }

--- a/scripts/test-prepare-readme.sh
+++ b/scripts/test-prepare-readme.sh
@@ -3,10 +3,17 @@
 # Tests for scripts/prepare-readme.sh.
 #
 # The golden case pins the original job -- stripping the zenodo badge and the
-# Documentation section. Everything after it covers link handling, where the failures
-# are invisible rather than loud: a relative link that reaches a marketplace page
-# resolves against the marketplace, and an absolute link to a path that moved is a 404.
-# Neither looks broken from inside the repository, which is why they are asserted here.
+# Documentation section. Everything after it covers the contract, which is small and
+# stated in two halves:
+#
+#   Supported:  [text](path) and ![alt](path) with a plain destination, plus anything
+#               already absolute. These are rewritten or left alone.
+#   Refused:    every other shape. Titles, angle brackets, reference definitions with
+#               relative targets. These stop the build.
+#
+# The refusals get as much attention as the rewrites here, because they are the contract.
+# A refusal that quietly stops firing turns into a relative link on a marketplace page,
+# which resolves against the marketplace and is invisible from inside the repository.
 #
 # Link targets are checked against the real repository, so these fixtures reference
 # files that genuinely exist (CONTRIBUTING.md, icon.png) and one that genuinely does not.
@@ -50,9 +57,19 @@ has() {
   grep -qF "$2" "$WORKSPACE/$1.out" || fail "$1: expected to find $2"
 }
 
+# Every refusal must name the destination it is refusing. The exit code alone is too weak
+# an assertion: a refusal that fires for the wrong reason still exits 1, and that is how
+# a check keeps passing after it has stopped testing what it was written for.
+refused() {
+  grep -qF "would not resolve on a listing page" "$WORKSPACE/$1.log" ||
+    fail "$1: expected the unsupported-destination message"
+  grep -qF "$2" "$WORKSPACE/$1.log" ||
+    fail "$1: expected the message to name $2"
+}
+
 # The missing-target cases need a path that genuinely is not in the repository. Checking
 # that here means adding the file later produces this message rather than an unexplained
-# failure in two fixtures that look like they are about something else.
+# failure in fixtures that look like they are about something else.
 MISSING="docs/NOPE.md"
 if [ -e "$REPO_ROOT/$MISSING" ]; then
   fail "the missing-target fixtures assume $MISSING does not exist, but it does now; point them at another path"
@@ -64,7 +81,7 @@ if ! diff -u "$EXPECTED" "$WORKSPACE/golden.out"; then
   fail "golden output no longer matches $EXPECTED"
 fi
 
-# --- Relative links become absolute, with the right base for each kind --------------
+# --- Supported: the two forms the contract rewrites ---------------------------------
 run relative-link 0 << 'EOF'
 # Title
 
@@ -80,318 +97,15 @@ run relative-image 0 << 'EOF'
 EOF
 has relative-image "]($RAW/icon.png)"
 
-run reference-definition 0 << 'EOF'
+# The image rule runs first for this reason: ![alt](path) contains the ](path) the link
+# rule matches, so the generic rule would hand an image the /blob/ base.
+run image-not-given-blob-base 0 << 'EOF'
 # Title
 
-[guide]: CONTRIBUTING.md
-
-Start with the [guide].
+![icon](icon.png) and [setup](CONTRIBUTING.md)
 EOF
-has reference-definition "[guide]: $BLOB/CONTRIBUTING.md"
-
-# A definition consumed by a reference-style image needs /raw/ like an inline image, not
-# the /blob/ every definition used to get -- a blob URL serves HTML and renders broken.
-run reference-image 0 << 'EOF'
-# Title
-
-![the icon][ic]
-
-[ic]: icon.png
-EOF
-has reference-image "[ic]: $RAW/icon.png"
-
-# The collapsed form takes its label from the alt text.
-run reference-image-collapsed 0 << 'EOF'
-# Title
-
-![ic][]
-
-[ic]: icon.png
-EOF
-has reference-image-collapsed "[ic]: $RAW/icon.png"
-
-# ...and the shortcut form, which is just the label with nothing after it.
-run reference-image-shortcut 0 << 'EOF'
-# Title
-
-![ic]
-
-[ic]: icon.png
-EOF
-has reference-image-shortcut "[ic]: $RAW/icon.png"
-
-# A definition routes on what its target is, not on how the label is used, so the same
-# label serving an image and a link is no longer a conflict -- it resolves once, by
-# extension. The trade is stated by the next two cases rather than left implicit.
-run label-used-both-ways 0 << 'EOF'
-# Title
-
-![pic][x] and [text][x]
-
-[x]: icon.png
-EOF
-has label-used-both-ways "[x]: $RAW/icon.png"
-
-# The limitation, written down: an image whose definition points at a non-image
-# extension gets /blob/ and would render broken. Nothing in this repository does that,
-# and the alternative -- deciding from usage -- is what produced three separate false
-# conflicts that refused to package correct READMEs.
-run definition-routes-by-extension 0 << 'EOF'
-# Title
-
-![pic][doc]
-
-[doc]: CONTRIBUTING.md
-EOF
-has definition-routes-by-extension "[doc]: $BLOB/CONTRIBUTING.md"
-
-# A definition may carry a title just as an inline link may. Handling it inline without
-# handling it here left the destination unrewritten and unreported -- shipped relative.
-run titled-definition 0 << 'EOF'
-# Title
-
-See [the guide][id].
-
-[id]: CONTRIBUTING.md "setup"
-EOF
-has titled-definition "[id]: $BLOB/CONTRIBUTING.md \"setup\""
-
-run titled-definition-image 0 << 'EOF'
-# Title
-
-![pic][ic]
-
-[ic]: icon.png "the icon"
-EOF
-has titled-definition-image "[ic]: $RAW/icon.png \"the icon\""
-
-# --- Angle-bracketed destinations are refused, whatever is inside them ---------------
-# The bracket form is legal Markdown that nothing here reads. It was briefly accepted by
-# stripping the bracket wherever a destination is inspected, which is a rule that has to
-# be repeated in every such place; the place that was missed treated `<#x>` as an anchor
-# and let a link into the removed section ship. One refusal covers the family instead, so
-# the three cases below differ only in what the brackets contain.
-run angle-bracket-url 1 << 'EOF'
-# Title
-
-See [example][id].
-
-[id]: <https://example.com>
-EOF
-grep -qF "angle-bracketed" "$WORKSPACE/angle-bracket-url.log" ||
-  fail "angle-bracket-url: expected the angle-bracket message"
-
-run angle-bracket-path 1 << 'EOF'
-# Title
-
-See [setup](<CONTRIBUTING.md>).
-EOF
-grep -qF "angle-bracketed" "$WORKSPACE/angle-bracket-path.log" ||
-  fail "angle-bracket-path: expected the angle-bracket message"
-
-# The one that shipped: an anchor into the stripped section, bracketed. It reached the
-# listing because `absolute()` saw an anchor after dropping the bracket while the
-# dangling-anchor scan, which looks for `](#`, did not see one at all.
-run angle-bracket-anchor 1 << 'EOF'
-# Title
-
-Jump to [the index](<#-documentation>).
-
-## 🔹 Documentation
-
-- something
-EOF
-grep -qF "angle-bracketed" "$WORKSPACE/angle-bracket-anchor.log" ||
-  fail "angle-bracket-anchor: expected the angle-bracket message"
-
-# ...but only in the part that survives. Refusing over a bracket in the section that is
-# cut would fail the release for something no reader of the listing could ever reach --
-# a false positive on the release path, the costlier direction to be wrong in.
-run angle-bracket-below-cut 0 << 'EOF'
-# Title
-
-Body.
-
-## 🔹 Documentation
-
-See [example](<https://example.com>).
-EOF
-
-# A tab is blank space in Markdown and the refusal has to see it. Worth a case of its own
-# because the first spelling of that check used [ \t], which POSIX reads as space,
-# backslash and the letter t -- it missed the tab and matched a stray t. The local grep on
-# a developer machine may be ugrep, which honours the escape and hides the difference.
-# Written with printf so the tab is unambiguous here rather than a character an editor eats.
-printf '# Title\n\nSee [setup](\t<CONTRIBUTING.md>).\n' > "$WORKSPACE/tab-before-bracket.in"
-got=0
-"$SCRIPT" "$WORKSPACE/tab-before-bracket.in" "$WORKSPACE/tab-before-bracket.out" \
-  > "$WORKSPACE/tab-before-bracket.log" 2>&1 || got=$?
-[ "$got" = 1 ] || fail "tab-before-bracket: expected exit 1, got $got"
-grep -qF "angle-bracketed" "$WORKSPACE/tab-before-bracket.log" ||
-  fail "tab-before-bracket: expected the angle-bracket message"
-
-# --- Reference definitions may be indented ------------------------------------------
-# Markdown allows up to three leading spaces before a definition, four being a code block.
-# The rewrite requires column zero and is deliberately left that way: growing what is
-# refused is safe, growing what is rewritten is what produced the regressions in this
-# branch. What changed is that the leftover scan no longer stops at column zero, so an
-# indented relative definition fails the build instead of shipping unrewritten and
-# unreported -- silently relative, which is the one outcome this script exists to prevent.
-run indented-definition-relative 1 << 'EOF'
-# Title
-
-  [guide]: CONTRIBUTING.md
-
-See the [guide].
-EOF
-grep -qF "relative links survived" "$WORKSPACE/indented-definition-relative.log" ||
-  fail "indented-definition-relative: expected the leftover-scan message"
-
-# The same indent with an absolute target is the form a listing can actually use, so it
-# passes untouched. Refusing it would block a release over nothing.
-run indented-definition-absolute 0 << 'EOF'
-# Title
-
-  [vs]: https://example.com
-
-See the [vs].
-EOF
-has indented-definition-absolute "  [vs]: https://example.com"
-
-run indented-definition-bracketed 1 << 'EOF'
-# Title
-
-  [id]: <https://example.com>
-EOF
-grep -qF "angle-bracketed" "$WORKSPACE/indented-definition-bracketed.log" ||
-  fail "indented-definition-bracketed: expected the angle-bracket message"
-
-# The indent allowance is spaces, not blank space. A leading tab is a four-column tab
-# stop, so a line starting with one is an indented code block and not a definition -- the
-# first spelling of this allowance counted the tab as one unit and refused a listing over
-# a code example. That is a false positive on the release path, which blocks a release
-# over a file that is correct, and is the costlier of the two directions to be wrong in.
-# printf again, so the tab is unambiguous here.
-printf '# Title\n\nAn example:\n\n\t[foo]: bar.md\n\nDone.\n' \
-  > "$WORKSPACE/tab-indented-code-definition.in"
-printf '# Title\n\nAn example:\n\n\t[foo]: <bar.md>\n\nDone.\n' \
-  > "$WORKSPACE/tab-indented-code-bracketed.in"
-for case in tab-indented-code-definition tab-indented-code-bracketed; do
-  got=0
-  "$SCRIPT" "$WORKSPACE/$case.in" "$WORKSPACE/$case.out" > "$WORKSPACE/$case.log" 2>&1 ||
-    got=$?
-  [ "$got" = 0 ] || {
-    fail "$case: expected exit 0, got $got"
-    sed 's/^/    /' "$WORKSPACE/$case.log" >&2
-  }
-done
-
-# A query or fragment after the extension does not stop it being an image, and does not
-# belong in the path that gets checked for existence either.
-run image-with-query 0 << 'EOF'
-# Title
-
-![pic][ic]
-
-[ic]: icon.png?raw=1
-EOF
-has image-with-query "[ic]: $RAW/icon.png?raw=1"
-
-run image-with-fragment 0 << 'EOF'
-# Title
-
-![pic][ic]
-
-[ic]: icon.png#v1
-EOF
-has image-with-fragment "[ic]: $RAW/icon.png#v1"
-
-# ...and it is still checked for existence, which the old shape skipped entirely.
-run titled-definition-missing 1 << 'EOF'
-# Title
-
-See [the plan][id].
-
-[id]: docs/NOPE.md "t"
-EOF
-grep -qF "not in the repository" "$WORKSPACE/titled-definition-missing.log" ||
-  fail "titled-definition-missing: expected the missing-file message"
-
-# Brackets that are not references at all. Each of these once counted as a shortcut link
-# and produced a conflict against the image, refusing to package a correct README --
-# a false positive on the release path, which is the costlier direction to be wrong in.
-run task-list-not-a-link 0 << 'EOF'
-# Title
-
-- [x] shipped
-
-![pic][x]
-
-[x]: icon.png
-EOF
-has task-list-not-a-link "[x]: $RAW/icon.png"
-
-run code-span-not-a-link 0 << 'EOF'
-# Title
-
-Write `[x]` to make a checkbox.
-
-![pic][x]
-
-[x]: icon.png
-EOF
-has code-span-not-a-link "[x]: $RAW/icon.png"
-
-run fenced-block-not-a-link 0 << 'EOF'
-# Title
-
-```md
-[x] and ![x]
-```
-
-![pic][x]
-
-[x]: icon.png
-EOF
-has fenced-block-not-a-link "[x]: $RAW/icon.png"
-
-# Link titles are legal Markdown and used to slip past the rewrite entirely: the
-# destination pattern stopped at the first space, so a titled relative link was neither
-# rewritten nor reported, which is the one outcome this script exists to prevent.
-run titled-link 0 << 'EOF'
-# Title
-
-See [setup](CONTRIBUTING.md "the guide") first.
-EOF
-has titled-link "]($BLOB/CONTRIBUTING.md \"the guide\")"
-
-run titled-image 0 << 'EOF'
-# Title
-
-![icon](icon.png "the icon")
-EOF
-has titled-image "]($RAW/icon.png \"the icon\")"
-
-run single-quoted-title 0 << 'EOF'
-# Title
-
-See [setup](CONTRIBUTING.md 'the guide') first.
-EOF
-has single-quoted-title "]($BLOB/CONTRIBUTING.md 'the guide')"
-
-# A destination shape the rewrite does not handle must fail rather than ship, including
-# shapes nobody has thought to name. Two titles is one such: the rewrite's title pattern
-# matches one and then wants the closing paren, so the link is passed over silently. The
-# leftover scan takes everything up to that paren and inspects the first token, which is
-# why it is deliberately broader than the rewrite -- the gap fails loudly instead of
-# shipping relative.
-run unsupported-destination 1 << 'EOF'
-# Title
-
-See [setup](CONTRIBUTING.md "one" "two").
-EOF
-grep -qF "relative links survived" "$WORKSPACE/unsupported-destination.log" ||
-  fail "unsupported-destination: expected the leftover-scan message"
+has image-not-given-blob-base "]($RAW/icon.png)"
+has image-not-given-blob-base "]($BLOB/CONTRIBUTING.md)"
 
 # A file link carrying an anchor keeps the anchor and is still checked for existence.
 run link-with-anchor 0 << 'EOF'
@@ -401,7 +115,7 @@ See [releases](CONTRIBUTING.md#creating-a-release).
 EOF
 has link-with-anchor "]($BLOB/CONTRIBUTING.md#creating-a-release)"
 
-# --- Absolute targets are left exactly as they are ----------------------------------
+# --- Supported: absolute destinations are left exactly as they are ------------------
 run absolute-untouched 0 << 'EOF'
 # Title
 
@@ -409,6 +123,189 @@ run absolute-untouched 0 << 'EOF'
 EOF
 has absolute-untouched "](https://example.com/page)"
 has absolute-untouched "](https://img.shields.io/badge/a-b-c.svg)"
+
+# A reference definition is never rewritten, so an absolute one has to pass untouched --
+# this is the form the repository's own README uses for its badge target.
+run absolute-definition 0 << 'EOF'
+# Title
+
+[vsmarketplace]: https://marketplace.visualstudio.com/items?itemName=michen00.invisible-squiggles
+
+[![badge](https://img.shields.io/badge/a-b-c.svg)][vsmarketplace]
+EOF
+has absolute-definition "[vsmarketplace]: https://marketplace.visualstudio.com"
+
+# ...at any indent Markdown allows for one.
+run absolute-definition-indented 0 << 'EOF'
+# Title
+
+  [vs]: https://example.com
+
+See the [vs].
+EOF
+has absolute-definition-indented "  [vs]: https://example.com"
+
+# --- Refused: titles ----------------------------------------------------------------
+# A title is legal Markdown. The rewrite's destination pattern stops at whitespace, so a
+# titled destination does not match it and arrives at the scan still relative. Refusing
+# is the whole point: the alternative is a title pattern, and every extension of that
+# pattern in this script's history produced the next defect.
+run titled-link 1 << 'EOF'
+# Title
+
+See [setup](CONTRIBUTING.md "the guide") first.
+EOF
+refused titled-link "CONTRIBUTING.md"
+
+run titled-image 1 << 'EOF'
+# Title
+
+![icon](icon.png "the icon")
+EOF
+refused titled-image "icon.png"
+
+run single-quoted-title 1 << 'EOF'
+# Title
+
+See [setup](CONTRIBUTING.md 'the guide') first.
+EOF
+refused single-quoted-title "CONTRIBUTING.md"
+
+# Two titles is a shape nobody would write on purpose. It is here because the scan has to
+# refuse forms nobody has thought of, not just the ones with names.
+run two-titles 1 << 'EOF'
+# Title
+
+See [setup](CONTRIBUTING.md "one" "two").
+EOF
+refused two-titles "CONTRIBUTING.md"
+
+# --- Refused: angle-bracketed destinations ------------------------------------------
+# Legal Markdown, unsupported here, and refused by the scan rather than by a rule of its
+# own. The scan normalises nothing, which is what makes this work: `<...>` never looks
+# absolute to it, so all three spellings arrive relative regardless of what is inside.
+run angle-bracket-path 1 << 'EOF'
+# Title
+
+See [setup](<CONTRIBUTING.md>).
+EOF
+refused angle-bracket-path "<CONTRIBUTING.md>"
+
+run angle-bracket-url 1 << 'EOF'
+# Title
+
+See [example][id].
+
+[id]: <https://example.com>
+EOF
+refused angle-bracket-url "<https://example.com>"
+
+# The one that shipped once: an anchor into the removed section, in brackets. It reached
+# the listing because a rule taught to strip the bracket made `<#...>` read as an anchor,
+# while the dangling-anchor scan -- which looks for `](#` -- saw no anchor at all.
+run angle-bracket-anchor 1 << 'EOF'
+# Title
+
+Jump to [the index](<#-documentation>).
+
+## 🔹 Documentation
+
+- something
+EOF
+refused angle-bracket-anchor "<#-documentation>"
+
+# --- Refused: reference definitions with relative targets ---------------------------
+# Definitions are not rewritten at all now. A relative one therefore reaches the scan and
+# stops the build, which is the honest outcome: it cannot be resolved without deciding
+# whether the label feeds an image or a link, and making that decision is what grew an
+# extension router and three separate false refusals of correct READMEs.
+run relative-definition 1 << 'EOF'
+# Title
+
+[guide]: CONTRIBUTING.md
+
+Start with the [guide].
+EOF
+refused relative-definition "CONTRIBUTING.md"
+
+run relative-definition-titled 1 << 'EOF'
+# Title
+
+[id]: CONTRIBUTING.md "setup"
+EOF
+refused relative-definition-titled "CONTRIBUTING.md"
+
+run relative-definition-indented 1 << 'EOF'
+# Title
+
+  [guide]: CONTRIBUTING.md
+EOF
+refused relative-definition-indented "CONTRIBUTING.md"
+
+# --- Not definitions, not links: these must not trip anything -----------------------
+# A leading tab is a four-column tab stop, so the line is an indented code block. Reading
+# it as a definition refused a listing over a code example -- a false positive on the
+# release path, which blocks a release over a file that is correct. printf, so the tab is
+# unambiguous in this source file rather than a character an editor may eat.
+printf '# Title\n\nAn example:\n\n\t[foo]: bar.md\n\nDone.\n' \
+  > "$WORKSPACE/tab-indented-code.in"
+got=0
+"$SCRIPT" "$WORKSPACE/tab-indented-code.in" "$WORKSPACE/tab-indented-code.out" \
+  > "$WORKSPACE/tab-indented-code.log" 2>&1 || got=$?
+[ "$got" = 0 ] || {
+  fail "tab-indented-code: expected exit 0, got $got"
+  sed 's/^/    /' "$WORKSPACE/tab-indented-code.log" >&2
+}
+
+# Brackets that are not links at all. An earlier design classified every bracket in the
+# document to decide what a definition fed; task list markers, code spans and fenced
+# examples each got read as a link and refused a correct README. Nothing scans usage now,
+# so the class is gone by construction -- these pin that it stays gone.
+run task-list-not-a-link 0 << 'EOF'
+# Title
+
+- [x] shipped
+
+See [CONTRIBUTING.md](CONTRIBUTING.md).
+EOF
+has task-list-not-a-link "]($BLOB/CONTRIBUTING.md)"
+
+run code-span-not-a-link 0 << 'EOF'
+# Title
+
+Write `[x]` to make a checkbox.
+
+See [CONTRIBUTING.md](CONTRIBUTING.md).
+EOF
+has code-span-not-a-link "]($BLOB/CONTRIBUTING.md)"
+
+run fenced-block-not-a-link 0 << 'EOF'
+# Title
+
+```md
+[x] and ![x]
+```
+
+See [CONTRIBUTING.md](CONTRIBUTING.md).
+EOF
+has fenced-block-not-a-link "]($BLOB/CONTRIBUTING.md)"
+
+# --- The stripped section is not held to the contract -------------------------------
+# The scan reads the output, and the output no longer contains the Documentation section,
+# so an unsupported shape below the cut cannot refuse a release over something no reader
+# of the listing could ever reach. This falls out of ordering rather than being arranged,
+# which is why it is worth pinning.
+run unsupported-below-the-cut 0 << 'EOF'
+# Title
+
+Body.
+
+## 🔹 Documentation
+
+See [setup](<CONTRIBUTING.md>) and [guide](CONTRIBUTING.md "titled").
+
+[ref]: CONTRIBUTING.md
+EOF
 
 # --- Anchors: allowed when the heading survives the strip ---------------------------
 # The slug matters more than it looks. GitHub lowercases, drops characters that are not


### PR DESCRIPTION
## What

`scripts/prepare-readme.sh` now states a small contract and enforces it, instead of trying to handle Markdown link syntax generally.

| | |
| --- | --- |
| **Rewritten** | `[text](path)` and `![alt](path)`, plain destination, no title |
| **Untouched** | any destination already absolute |
| **Refused** | titles, angle brackets, reference definitions pointing somewhere relative, anchors into the removed section |

A refused destination stops the build with a message naming it and saying what to write instead.

## Why

The refused forms are not gaps. Every one of them was handled at some point, and handling them is what went wrong. Supporting titles meant a title pattern in three places. Supporting `<https://…>` meant stripping the bracket wherever a destination is read — and the one place that was missed let an anchor into the removed section ship. Supporting reference definitions meant deciding whether a label fed an image or a link, which meant classifying every bracket in the document, which read task list markers, code spans and fenced examples as links and refused three correct READMEs before being replaced by an extension router.

That produced ten review findings, five of them regressions from the fix immediately before. The pattern was not bad luck: each fix widened the grammar the script claimed to handle, and a wider grammar always has a next edge.

None of it made a listing safer. The guarantee — nothing relative reaches a marketplace page — is enforced by the leftover scan, which reads the *output* and is indifferent to how it was produced. Narrowing the rewrite does not touch it. The forms now refused are refused **by** that scan rather than by rules of their own, which is why the angle-bracket check could be deleted outright: the scan normalises nothing, so `<…>` never looks absolute to it, whatever is inside.

## Why narrow is right here specifically

The input is one file, in this repository, written by the people who receive the error, and checked by CI. "Make it absolute, or write it plainly" costs an author seconds, and a refusal that fires wrongly stops a release loudly rather than editing a listing silently.

That reasoning is what licenses the narrowness and it would not transfer to a tool processing Markdown you do not control. It is written down in the script header so the next person to hit a refusal can see the trade rather than assume an oversight.

## One thing that is not just deletion

The destination pattern excludes `<` and quotes as well as whitespace. Without excluding `<`, the rewrite treats `<CONTRIBUTING.md>` as a path and bolts a base onto it, and the failure surfaces from the existence check as `links '<CONTRIBUTING.md>', which is not in the repository` — true, useless, and pointing at the wrong repair. Excluding it is what routes every unsupported shape to the one message that explains the contract.

## Verification

Output is unchanged, checked three ways:

- Byte-identical for the golden fixture, `scripts/fixtures/test-readme-expected.md`.
- Byte-identical for `README.md` against the previous script.
- Byte-identical to the `readme.md` **currently served by Open VSX for 0.4.2** — the transform's real output, fetched from the registry rather than rebuilt.

`make check` and `make package-vsix` both pass. The suite runs green under two grep implementations, which matters here because they disagree about escapes inside bracket expressions.

## Test changes

The suite is reorganised around the contract: supported forms, refused forms, and things that are neither. Refusal cases now assert on the *message and the named destination*, not just the exit code — a refusal firing for the wrong reason still exits 1, and that is how a check keeps passing after it has stopped testing what it was written for.

Cases for behaviour that no longer exists are gone (definition rewriting, extension routing, titled definitions). Cases pinning behaviour that must not come back are kept and, where the old fixtures relied on definition rewriting, rewritten: the task list, code span and fenced block tests still prove that brackets which are not links do not trip anything, now by construction rather than by exclusion.

## Size

Modest, and worth stating plainly rather than overselling: 393 → 326 code lines across both files, about 17%. The value is not the deletion. It is that the grammar has a stated boundary and stops growing.
